### PR TITLE
fix: dotenv -> dotenvy

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1781,6 +1781,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "dotenvy"
+version = "0.15.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03d8c417d7a8cb362e0c37e5d815f5eb7c37f79ff93707329d5a194e42e54ca0"
+
+[[package]]
 name = "either"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5155,8 +5161,8 @@ dependencies = [
  "dashmap 5.4.0",
  "datafusion",
  "datafusion-common",
- "dotenv",
  "dotenv_config",
+ "dotenvy",
  "env_logger",
  "etcd-client",
  "flatten-json-object",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1763,21 +1763,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
 
 [[package]]
-name = "dotenv"
-version = "0.15.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77c90badedccf4105eca100756a0b1289e191f6fcbdadd3cee1d2f614f97da8f"
-
-[[package]]
 name = "dotenv_config"
-version = "0.1.3"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "850c634409912953e23d6ef00eef1b09367a4ca7429eb34f937a88116bb9a60b"
+checksum = "cc8db7cd099cfe5d7b33f170b3d19054045425fe6d0d876defb7912c31d2fb67"
 dependencies = [
  "anyhow",
  "askama",
  "convert_case 0.6.0",
- "dotenv",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,8 +43,8 @@ chrono = "0.4"
 dashmap = {version = "5.4.0", features = ["serde"]}
 datafusion = {version = "17.0", features = ["simd"]}
 datafusion-common = "17.0"
+dotenv_config = "0.1.5"
 dotenvy = "0.15.6"
-dotenv_config = "0.1.3"
 env_logger = "0.9"
 etcd-client = {version = "0.10.2", features = ["tls"]}
 flatten-json-object = "0.6.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,7 @@ chrono = "0.4"
 dashmap = {version = "5.4.0", features = ["serde"]}
 datafusion = {version = "17.0", features = ["simd"]}
 datafusion-common = "17.0"
-dotenv = "0.15.0"
+dotenvy = "0.15.6"
 dotenv_config = "0.1.3"
 env_logger = "0.9"
 etcd-client = {version = "0.10.2", features = ["tls"]}

--- a/build.rs
+++ b/build.rs
@@ -112,11 +112,11 @@ fn main() -> Result<()> {
         .output()
         .unwrap();
     let git_commit = String::from_utf8(output.stdout).unwrap();
-    println!("cargo:rustc-env=GIT_COMMIT={}", git_commit);
+    println!("cargo:rustc-env=GIT_COMMIT_HASH={}", git_commit);
 
     let now: DateTime<Utc> = Utc::now();
     let build_date = now.to_rfc3339_opts(SecondsFormat::Secs, true);
-    println!("cargo:rustc-env=GIT_DATE={}", build_date);
+    println!("cargo:rustc-env=GIT_BUILD_DATE={}", build_date);
 
     Ok(())
 }

--- a/src/infra/config.rs
+++ b/src/infra/config.rs
@@ -14,8 +14,8 @@
 
 use dashmap::DashMap;
 use datafusion::arrow::datatypes::Schema;
-use dotenvy::dotenv;
 use dotenv_config::EnvConfig;
+use dotenvy::dotenv;
 use reqwest::Client;
 use std::time::Duration;
 use sys_info::hostname;

--- a/src/infra/config.rs
+++ b/src/infra/config.rs
@@ -27,8 +27,8 @@ use crate::meta::prom::ClusterLeader;
 use crate::meta::user::User;
 
 pub static VERSION: &str = env!("GIT_VERSION");
-pub static COMMIT_HASH: &str = env!("GIT_COMMIT");
-pub static BUILD_DATE: &str = env!("GIT_DATE");
+pub static COMMIT_HASH: &str = env!("GIT_COMMIT_HASH");
+pub static BUILD_DATE: &str = env!("GIT_BUILD_DATE");
 #[cfg(feature = "zo_functions")]
 pub static HAS_FUNCTIONS: bool = true;
 #[cfg(not(feature = "zo_functions"))]

--- a/src/infra/config.rs
+++ b/src/infra/config.rs
@@ -14,7 +14,7 @@
 
 use dashmap::DashMap;
 use datafusion::arrow::datatypes::Schema;
-use dotenv::dotenv;
+use dotenvy::dotenv;
 use dotenv_config::EnvConfig;
 use reqwest::Client;
 use std::time::Duration;


### PR DESCRIPTION
Move from dotenv to dotenvy which is a well maintained fork of dotenv.