### PR TITLE
refactor: apply `Option::unwrap_or`

### DIFF
--- a/src/handler/http/request/stream/mod.rs
+++ b/src/handler/http/request/stream/mod.rs
@@ -55,10 +55,7 @@ async fn schema(
             )
         }
     };
-    let stream_type = match stream_type {
-        Some(v) => v,
-        None => StreamType::Logs,
-    };
+    let stream_type = stream_type.unwrap_or(StreamType::Logs);
     stream::get_stream(&org_id, &stream_name, stream_type).await
 }
 
@@ -98,11 +95,7 @@ async fn settings(
             )
         }
     };
-
-    let stream_type = match stream_type {
-        Some(v) => v,
-        None => StreamType::Logs,
-    };
+    let stream_type = stream_type.unwrap_or(StreamType::Logs);
     stream::save_stream_settings(&org_id, &stream_name, stream_type, settings.into_inner()).await
 }
 
@@ -140,10 +133,7 @@ async fn delete(
             )
         }
     };
-    let stream_type = match stream_type {
-        Some(v) => v,
-        None => StreamType::Logs,
-    };
+    let stream_type = stream_type.unwrap_or(StreamType::Logs);
     stream::delete_stream(&org_id, &stream_name, stream_type).await
 }
 

--- a/src/service/db/schema.rs
+++ b/src/service/db/schema.rs
@@ -30,10 +30,7 @@ pub async fn get(
     stream_type: Option<StreamType>,
 ) -> Result<Schema, anyhow::Error> {
     let mut value = Schema::empty();
-    let stream_type = match stream_type {
-        Some(v) => v,
-        None => StreamType::Logs,
-    };
+    let stream_type = stream_type.unwrap_or(StreamType::Logs);
     let key = format!("/schema/{}/{}/{}", org_id, stream_type, stream_name);
     let map_key = key.strip_prefix("/schema/").unwrap();
     if STREAM_SCHEMAS.contains_key(map_key) {
@@ -67,10 +64,7 @@ pub async fn get_versions(
     stream_type: Option<StreamType>,
 ) -> Result<Vec<Schema>, anyhow::Error> {
     let mut value = vec![];
-    let stream_type = match stream_type {
-        Some(v) => v,
-        None => StreamType::Logs,
-    };
+    let stream_type = stream_type.unwrap_or(StreamType::Logs);
     let key = format!("/schema/{}/{}/{}", org_id, stream_type, stream_name);
     let map_key = key.strip_prefix("/schema/").unwrap();
     if STREAM_SCHEMAS.contains_key(map_key) {
@@ -154,10 +148,7 @@ pub async fn delete(
     stream_name: &str,
     stream_type: Option<StreamType>,
 ) -> Result<(), anyhow::Error> {
-    let stream_type = match stream_type {
-        Some(v) => v,
-        None => StreamType::Logs,
-    };
+    let stream_type = stream_type.unwrap_or(StreamType::Logs);
     let key = format!("/schema/{}/{}/{}", org_id, stream_type, stream_name);
     let db = &crate::infra::db::DEFAULT;
     match db.delete(&key, false).await {

--- a/src/service/file_list.rs
+++ b/src/service/file_list.rs
@@ -26,10 +26,7 @@ pub async fn get_file_list(
     time_min: i64,
     time_max: i64,
 ) -> Result<Vec<String>, anyhow::Error> {
-    let stream_type_loc = match stream_type {
-        Some(v) => v,
-        None => StreamType::Logs,
-    };
+    let stream_type_loc = stream_type.unwrap_or(StreamType::Logs);
     file_list::get_file_list(org_id, stream_name, stream_type_loc, time_min, time_max).await
 }
 


### PR DESCRIPTION
`match stream_type` blocks are overly verbose. Replace them with more concise `stream_type.unwrap_or` expressions.