### PR TITLE
refactor: refactor the unit tests

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -101,5 +101,5 @@ zstd = "0.12.1"
 
 [build-dependencies]
 chrono = "0.4"
-prost-build = {version = "0.11.2"}
+prost-build = "0.11"
 tonic-build = {version = "0.8", features = ["prost"]}

--- a/src/common/auth.rs
+++ b/src/common/auth.rs
@@ -59,8 +59,7 @@ mod tests {
 
     #[actix_web::test]
     async fn test_is_root_user() {
-        let res = is_root_user("dummy").await;
-        assert_eq!(res, false)
+        assert!(!is_root_user("dummy").await);
     }
 
     #[actix_web::test]
@@ -76,17 +75,14 @@ mod tests {
             },
         )
         .await;
-        let res = is_root_user("root@example.com").await;
-        assert_eq!(res, true);
-        let res = is_root_user("root2@example.com").await;
-        assert_eq!(res, false);
+        assert!(is_root_user("root@example.com").await);
+        assert!(!is_root_user("root2@example.com").await);
     }
 
     #[actix_web::test]
     async fn test_get_hash() {
         let hash =
             "$argon2d$v=16$m=2048,t=4,p=2$VGVzdFNhbHQ$CZzrFPtqjY4mIPYwoDztCJ3OGD5M0P37GH4QddwrbZk";
-        let res = get_hash("Pass#123", "TestSalt");
-        assert_eq!(res, hash);
+        assert_eq!(get_hash("Pass#123", "TestSalt"), hash);
     }
 }

--- a/src/common/base64.rs
+++ b/src/common/base64.rs
@@ -46,11 +46,7 @@ mod tests {
     #[test]
     fn test_decode() {
         let s = "aGVsbG8gd29ybGQ=";
-        let s = decode(s).unwrap();
-        assert_eq!(s, "hello world");
-
-        let s = "aGVsbG8gd29ybGQ";
-        let s = decode(s);
-        assert_eq!(s.is_err(), true);
+        assert_eq!(decode(s).unwrap(), "hello world");
+        assert!(decode(&s[..s.len() - 1]).is_err());
     }
 }

--- a/src/common/file.rs
+++ b/src/common/file.rs
@@ -39,18 +39,11 @@ pub fn put_file_contents(file: &str, contents: &[u8]) -> Result<(), std::io::Err
 }
 
 #[inline(always)]
-pub fn delete_file(file: &str) -> Result<(), std::io::Error> {
-    std::fs::remove_file(file)?;
-    Ok(())
-}
-
-#[inline(always)]
 pub fn scan_files(pattern: &str) -> Vec<String> {
-    let files: Vec<String> = glob::glob(pattern)
+    glob::glob(pattern)
         .unwrap()
         .map(|m| m.unwrap().to_str().unwrap().to_string())
-        .collect();
-    files
+        .collect()
 }
 
 #[cfg(test)]
@@ -61,19 +54,11 @@ mod tests {
     fn test_file() {
         let content = b"Some Text";
         let file_name = "sample.parquet";
-        let resp = put_file_contents(file_name, content);
-        assert!(resp.is_ok());
 
-        let resp = get_file_contents(file_name);
-        assert_eq!(resp.unwrap(), content);
-
-        let resp = get_file_meta(file_name);
-        assert_eq!(resp.unwrap().is_file(), true);
-
-        let resp = scan_files(file_name);
-        assert!(resp.len() > 0);
-
-        let resp = delete_file(file_name);
-        assert!(resp.is_ok());
+        put_file_contents(file_name, content).unwrap();
+        assert_eq!(get_file_contents(file_name).unwrap(), content);
+        assert!(get_file_meta(file_name).unwrap().is_file());
+        assert!(!scan_files(file_name).is_empty());
+        std::fs::remove_file(file_name).unwrap();
     }
 }

--- a/src/common/str.rs
+++ b/src/common/str.rs
@@ -31,7 +31,6 @@ mod tests {
     fn test_find() {
         let haystack = "This is search-unitTest";
         let needle = "unitTest";
-        let result = find(haystack, needle);
-        assert_eq!(result, true)
+        assert!(find(haystack, needle));
     }
 }

--- a/src/handler/grpc/auth/mod.rs
+++ b/src/handler/grpc/auth/mod.rs
@@ -100,8 +100,7 @@ mod tests {
         let meta: &mut tonic::metadata::MetadataMap = request.metadata_mut();
         meta.insert("authorization", token.clone());
 
-        let res = check_auth(request);
-        assert!(res.is_ok())
+        assert!(check_auth(request).is_ok())
     }
 
     #[actix_web::test]

--- a/src/handler/grpc/mod.rs
+++ b/src/handler/grpc/mod.rs
@@ -111,7 +111,6 @@ mod test {
 
         let rpc_meta = cluster_rpc::FileMeta::from(&file_meta);
         let resp = meta::common::FileMeta::from(&rpc_meta);
-
         assert_eq!(file_meta, resp);
     }
 

--- a/src/handler/http/auth/mod.rs
+++ b/src/handler/http/auth/mod.rs
@@ -132,23 +132,12 @@ mod tests {
         )
         .await;
 
-        let user_password = "Complexpass#123";
-        let res = validate_credentials("root@example.com", user_password, "default/_bulk").await;
-        assert_eq!(res.unwrap(), true);
-
-        let res = validate_credentials("", user_password, "default/_bulk").await;
-        assert_eq!(res.unwrap(), false);
-
-        let res = validate_credentials("", user_password, "/").await;
-        assert_eq!(res.unwrap(), false);
-
-        let res = validate_credentials("user@example.com", user_password, "").await;
-        assert_eq!(res.unwrap(), true);
-
-        let res = validate_credentials("user@example.com", user_password, "default/user").await;
-        assert_eq!(res.unwrap(), true);
-
-        let res = validate_credentials("user@example.com", "x", "default/user").await;
-        assert_eq!(res.unwrap(), false);
+        let pwd = "Complexpass#123";
+        assert!(validate_credentials("root@example.com", pwd, "default/_bulk").await.unwrap());
+        assert!(!validate_credentials("", pwd, "default/_bulk").await.unwrap());
+        assert!(!validate_credentials("", pwd, "/").await.unwrap());
+        assert!(validate_credentials("user@example.com", pwd, "").await.unwrap());
+        assert!(validate_credentials("user@example.com", pwd, "default/user").await.unwrap());
+        assert!(!validate_credentials("user@example.com", "x", "default/user").await.unwrap());
     }
 }

--- a/src/infra/cache/file_data.rs
+++ b/src/infra/cache/file_data.rs
@@ -169,22 +169,12 @@ mod tests {
         let file_key = "files/default/logs/olympics/2022/10/03/10/6982652937134804993_1.parquet";
         let content = Bytes::from("Some text");
 
-        let resp = file_data.set(file_key, content.clone());
-        assert!(resp.is_ok());
+        file_data.set(file_key, content.clone()).unwrap();
+        assert_eq!(file_data.get(file_key).unwrap(), content);
 
-        let resp = file_data.get(file_key);
-        assert_eq!(resp.unwrap(), content);
-
-        let resp = set(file_key, content.clone());
-        assert!(resp.is_ok());
-
-        let resp = exist(file_key);
-        assert_eq!(resp.unwrap(), true);
-
-        let resp = get(file_key);
-        assert_eq!(resp.unwrap(), content);
-
-        let resp = stats();
-        assert!(resp.0 > 0);
+        set(file_key, content.clone()).unwrap();
+        assert!(exist(file_key).unwrap());
+        assert_eq!(get(file_key).unwrap(), content);
+        assert!(stats().0 > 0);
     }
 }

--- a/src/infra/cache/stats.rs
+++ b/src/infra/cache/stats.rs
@@ -157,8 +157,7 @@ mod tests {
     #[test]
     fn test_get_stream_stats_len() {
         let stats = get_stats();
-        let data = get_stream_stats_len();
-        assert_eq!(data, stats.len());
+        assert_eq!(get_stream_stats_len(), stats.len());
 
         let val = StreamStats {
             doc_time_min: 1667978841102,

--- a/src/infra/cache/tmpfs.rs
+++ b/src/infra/cache/tmpfs.rs
@@ -165,16 +165,16 @@ mod tests {
     fn create_read_file() {
         let path = "/tmp/test.txt";
         let _ = write_file(path, b"hello world").unwrap();
-        let data = read_file(path).unwrap();
-        assert_eq!(data, b"hello world");
+        assert_eq!(read_file(path).unwrap(), b"hello world");
         remove_file(path).unwrap();
     }
 
     #[test]
     fn create_read_directory() {
-        assert_eq!(true, create_dir_all("/tmp/test_dir/abc/").is_ok());
-        assert_eq!(true, create_dir("/tmp/test_dir/abc/cde/").is_ok());
-        assert_eq!(true, remove_dir("/tmp/test_dir/abc/cde/").is_ok());
-        assert_eq!(true, remove_dir_all("/tmp/test_dir/").is_ok());
+        assert!(create_dir("/tmp/test_dir/abc/cde/").is_err());
+        create_dir_all("/tmp/test_dir/abc/").unwrap();
+        create_dir("/tmp/test_dir/abc/cde/").unwrap();
+        remove_dir("/tmp/test_dir/abc/cde/").unwrap();
+        remove_dir_all("/tmp/test_dir/").unwrap();
     }
 }

--- a/src/infra/storage/local.rs
+++ b/src/infra/storage/local.rs
@@ -83,16 +83,12 @@ mod test_util {
         let file_text = "Some text";
         let file_name = "a/b/c/new_file.parquet";
 
-        let resp = local.put(file_name, bytes::Bytes::from(file_text)).await;
-        assert!(resp.is_ok());
-
-        let resp = local.get(file_name).await;
-        assert_eq!(resp.unwrap(), bytes::Bytes::from(file_text));
+        local.put(file_name, bytes::Bytes::from(file_text)).await.unwrap();
+        assert_eq!(local.get(file_name).await.unwrap(), bytes::Bytes::from(file_text));
 
         let resp = local.list("").await;
         assert!(resp.unwrap().contains(&file_name.to_string()));
 
-        let resp = local.del(&[file_name]).await;
-        assert!(resp.is_ok());
+        local.del(&[file_name]).await.unwrap();
     }
 }

--- a/src/service/db/compact/file_list.rs
+++ b/src/service/db/compact/file_list.rs
@@ -52,8 +52,7 @@ pub async fn list_delete() -> Result<Vec<String>, anyhow::Error> {
     let mut items = Vec::new();
     let db = &crate::infra::db::DEFAULT;
     let key = "/compact/file_list/delete/";
-    let ret = db.list(key).await?;
-    for (item_key, _item_value) in ret {
+    for (item_key, _item_value) in db.list(key).await? {
         let item_key = item_key.strip_prefix(key).unwrap();
         items.push(item_key.to_string());
     }
@@ -62,20 +61,17 @@ pub async fn list_delete() -> Result<Vec<String>, anyhow::Error> {
 
 #[cfg(test)]
 mod tests {
-
     use super::*;
 
     #[actix_web::test]
     async fn test_files() {
-        let off_set = 100;
+        const OFFSET: i64 = 100;
 
-        let _ = set_offset(off_set).await;
-        let resp = get_offset().await;
-        assert_eq!(resp.unwrap(), off_set);
+        set_offset(OFFSET).await.unwrap();
+        assert_eq!(get_offset().await.unwrap(), OFFSET);
 
         let delete_day = "2023-03-03";
-        let _ = set_delete(delete_day).await;
-        let deletes = list_delete().await.unwrap();
-        assert_eq!([delete_day.to_string()].to_vec(), deletes);
+        set_delete(delete_day).await.unwrap();
+        assert_eq!(list_delete().await.unwrap(), vec![delete_day.to_string()]);
     }
 }

--- a/src/service/db/compact/files.rs
+++ b/src/service/db/compact/files.rs
@@ -74,18 +74,14 @@ pub async fn list_offset() -> Result<Vec<(String, i64)>, anyhow::Error> {
 
 #[cfg(test)]
 mod tests {
-
     use super::*;
 
     #[actix_web::test]
     async fn test_files() {
-        let off_set = 100;
+        const OFFSET: i64 = 100;
 
-        let _ = set_offset("nexus", "default", "logs".into(), off_set).await;
-        let resp = get_offset("nexus", "default", "logs".into()).await;
-        assert_eq!(resp.unwrap(), off_set);
-
-        let resp = list_offset().await;
-        assert!(resp.unwrap().len() > 0);
+        set_offset("nexus", "default", "logs".into(), OFFSET).await.unwrap();
+        assert_eq!(get_offset("nexus", "default", "logs".into()).await.unwrap(), OFFSET);
+        assert!(!list_offset().await.unwrap().is_empty());
     }
 }

--- a/src/service/router/mod.rs
+++ b/src/service/router/mod.rs
@@ -88,39 +88,34 @@ pub async fn dispatch(
 
     // copy headers
     for (key, value) in resp.headers() {
-        if key.eq("content-encoding") {
-            continue;
+        if !key.eq("content-encoding") {
+            new_resp.insert_header((key.clone(), value.clone()));
         }
-        new_resp.insert_header((key.clone(), value.clone()));
     }
+
     // set body
     let body = resp
         .body()
         .limit(CONFIG.limit.req_payload_limit)
         .await
         .unwrap();
-    let new_resp = new_resp.body(body);
-
-    Ok(new_resp)
+    Ok(new_resp.body(body))
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+
     #[test]
     fn test_is_router() {
-        let is_router = is_router();
-        assert_eq!(is_router, false);
+        assert!(!is_router());
     }
+
     #[test]
     fn test_check_search_route() {
-        let is_search_route = check_search_route("/api/_search");
-        assert_eq!(is_search_route, true);
-        let is_search_route = check_search_route("/api/_around");
-        assert_eq!(is_search_route, true);
-        let is_search_route = check_search_route("/api/cache/status");
-        assert_eq!(is_search_route, true);
-        let is_search_route = check_search_route("/api/_bulk");
-        assert_eq!(is_search_route, false);
+        assert!(check_search_route("/api/_search"));
+        assert!(check_search_route("/api/_around"));
+        assert!(check_search_route("/api/cache/status"));
+        assert!(!check_search_route("/api/_bulk"));
     }
 }

--- a/src/service/schema.rs
+++ b/src/service/schema.rs
@@ -325,11 +325,12 @@ mod test {
     use super::*;
     use ahash::AHashMap;
     use datafusion::arrow::datatypes::{DataType, Field, Schema};
+
     #[test]
     fn test_is_widening_conversion() {
-        let res = is_widening_conversion(&DataType::Int8, &DataType::Int32);
-        assert_eq!(res, true);
+        assert!(is_widening_conversion(&DataType::Int8, &DataType::Int32));
     }
+
     #[test]
     fn test_try_merge() {
         let merged = try_merge(vec![
@@ -377,6 +378,6 @@ mod test {
             1234234234234,
         )
         .await;
-        assert_eq!(result.0, true);
+        assert!(result.0);
     }
 }

--- a/src/service/search/datafusion/regexp_udf.rs
+++ b/src/service/search/datafusion/regexp_udf.rs
@@ -258,11 +258,11 @@ mod tests {
 
     #[test]
     fn parse_escape() {
-        assert_eq!(is_valid_character_after_escape('0'), true);
-        assert_eq!(is_valid_character_after_escape('8'), true);
-        assert_eq!(is_valid_character_after_escape('x'), true);
-        assert_eq!(is_valid_character_after_escape('p'), true);
-        assert_eq!(is_valid_character_after_escape('d'), true);
-        assert_eq!(is_valid_character_after_escape('a'), false);
+        assert!(is_valid_character_after_escape('0'));
+        assert!(is_valid_character_after_escape('8'));
+        assert!(is_valid_character_after_escape('x'));
+        assert!(is_valid_character_after_escape('p'));
+        assert!(is_valid_character_after_escape('d'));
+        assert!(!is_valid_character_after_escape('a'));
     }
 }

--- a/src/service/users.rs
+++ b/src/service/users.rs
@@ -380,25 +380,23 @@ mod tests {
             },
         );
     }
+
     #[actix_web::test]
     async fn test_list_users() {
         set_up().await;
-        let resp = list_users("dummy").await;
-        assert!(resp.is_ok())
+        assert!(list_users("dummy").await.is_ok())
     }
+
     #[actix_web::test]
     async fn test_root_user_exists() {
         set_up().await;
-        let resp = root_user_exists().await;
-        assert_eq!(resp, false)
+        assert!(!root_user_exists().await);
     }
 
     #[actix_web::test]
     async fn test_get_user() {
         set_up().await;
-
-        let resp = get_user(Some("dummy"), "admin@zo.dev").await;
-        assert_eq!(resp.is_some(), true)
+        assert!(get_user(Some("dummy"), "admin@zo.dev").await.is_some())
     }
 
     #[actix_web::test]


### PR DESCRIPTION
Pattern 1
---------

Before:
```rust
        assert_eq!(a, true);
        assert_eq!(b, false);
```

After:
```rust
        assert!(a);
        assert!(!b);
```

Rationale: if `assert_eq!(pred, true)` is clearer than `assert!(pred)`,
then `assert_eq!(pred == true, true)` is even more clearer.

Pattern 2
---------

Before:
```rust
    match pred {
        true => {
            // ...
        }
        false => {
            // ...
        }
    }
```

After:
```rust
    if pred {
        // ...
    } else {
        // ...
    }
```

Pattern 3
---------

Before:
```rust
    #[test]
    fn example() {
        // `f` returns `Result<(), Error>`
        assert!(f().is_ok());
    }
```

After:
```rust
    #[test]
    fn example() {
        // `f` returns `Result<(), Error>`
        f().unwrap();
    }
```

Wat
---

Before:
```rust
    #[test]
    fn test_is_router() {
        let is_router = is_router();
        assert_eq!(is_router, false);
    }
```

After:
```rust
    #[test]
    fn test_is_router() {
        assert!(!is_router();
    }
```
