### PR TITLE
refactor: inline format args; ci: deny clippy warnings

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -105,18 +105,18 @@ fn main() -> Result<()> {
         .output()
         .unwrap();
     let git_tag = String::from_utf8(output.stdout).unwrap();
-    println!("cargo:rustc-env=GIT_VERSION={}", git_tag);
+    println!("cargo:rustc-env=GIT_VERSION={git_tag}");
 
     let output = Command::new("git")
         .args(["rev-parse", "HEAD"])
         .output()
         .unwrap();
     let git_commit = String::from_utf8(output.stdout).unwrap();
-    println!("cargo:rustc-env=GIT_COMMIT_HASH={}", git_commit);
+    println!("cargo:rustc-env=GIT_COMMIT_HASH={git_commit}");
 
     let now: DateTime<Utc> = Utc::now();
     let build_date = now.to_rfc3339_opts(SecondsFormat::Secs, true);
-    println!("cargo:rustc-env=GIT_BUILD_DATE={}", build_date);
+    println!("cargo:rustc-env=GIT_BUILD_DATE={build_date}");
 
     Ok(())
 }

--- a/deploy/build/buildspec-test.yml
+++ b/deploy/build/buildspec-test.yml
@@ -24,5 +24,5 @@ phases:
       - chmod 600 /swapfile
       - mkswap /swapfile
       - swapon /swapfile
-      - cargo clippy -- -A clippy::uninlined_format_args
+      - cargo clippy -- -D warnings
       - ./coverage.sh

--- a/src/common/auth.rs
+++ b/src/common/auth.rs
@@ -21,7 +21,7 @@ use crate::{
 };
 
 pub fn get_hash(pass: &str, salt: &str) -> String {
-    let key = format!("{}{}", pass, salt);
+    let key = format!("{pass}{salt}");
     let hash = PASSWORD_HASH.get(&key);
     match hash {
         Some(ret_hash) => ret_hash.value().to_string(),
@@ -44,7 +44,7 @@ pub fn get_hash(pass: &str, salt: &str) -> String {
 }
 
 pub async fn is_root_user(user_id: &str) -> bool {
-    let key = format!("{}/{}", DEFAULT_ORG, user_id);
+    let key = format!("{DEFAULT_ORG}/{user_id}");
     match USERS.get(&key) {
         Some(user) => user.role.eq(&UserRole::Root),
         None => false,

--- a/src/common/base64.rs
+++ b/src/common/base64.rs
@@ -22,7 +22,7 @@ pub fn decode(s: &str) -> Result<String, Error> {
         Err(e) => {
             return Err(Error::new(
                 ErrorKind::InvalidData,
-                format!("base64 decode error: {}", e),
+                format!("base64 decode error: {e}"),
             ))
         }
     };
@@ -31,7 +31,7 @@ pub fn decode(s: &str) -> Result<String, Error> {
         Err(e) => {
             return Err(Error::new(
                 ErrorKind::InvalidData,
-                format!("base64 decode error: {}", e),
+                format!("base64 decode error: {e}"),
             ))
         }
     };

--- a/src/common/notification.rs
+++ b/src/common/notification.rs
@@ -46,7 +46,7 @@ pub async fn send_notification(
                 // Replace contextual information with values if any from alert
                 if alert.context_attributes.is_some() {
                     for (key, value) in alert.context_attributes.as_ref().unwrap() {
-                        resp = resp.replace(&format!("{{{}}}", key), value)
+                        resp = resp.replace(&format!("{{{key}}}"), value)
                     }
                 }
 

--- a/src/handler/http/request/organization/mod.rs
+++ b/src/handler/http/request/organization/mod.rs
@@ -73,7 +73,7 @@ pub async fn organizations(credentials: BasicAuth) -> Result<HttpResponse, Error
         if !user.key().contains('/') {
             continue;
         }
-        if !is_root_user && !user.key().ends_with(format!("/{}", user_id).as_str()) {
+        if !is_root_user && !user.key().ends_with(&format!("/{user_id}")) {
             continue;
         }
 

--- a/src/handler/http/request/search/mod.rs
+++ b/src/handler/http/request/search/mod.rs
@@ -498,7 +498,7 @@ pub async fn values(
     // search
     let mut req = meta::search::Request {
         query: meta::search::Query {
-            sql: format!("SELECT * FROM {}", stream_name),
+            sql: format!("SELECT * FROM {stream_name}"),
             from: 0,
             size: 0,
             start_time,
@@ -514,8 +514,7 @@ pub async fn values(
         req.aggs.insert(
             field.clone(),
             format!(
-                "SELECT {} AS key, COUNT(*) AS num FROM query GROUP BY key ORDER BY num DESC LIMIT {}",
-                field, size
+                "SELECT {field} AS key, COUNT(*) AS num FROM query GROUP BY key ORDER BY num DESC LIMIT {size}"
             ),
         );
     }

--- a/src/handler/http/router/mod.rs
+++ b/src/handler/http/router/mod.rs
@@ -75,7 +75,9 @@ pub fn get_basic_routes(cfg: &mut web::ServiceConfig) {
                     let path = req.path().strip_prefix(&prefix).unwrap().to_string();
 
                     srv.call(req).map(move |res| {
-                        if !path.starts_with("src/") && !path.starts_with("assets/") {
+                        if path.starts_with("src/") || path.starts_with("assets/") {
+                            res
+                        } else {
                             let res = res.unwrap();
                             let req = res.request().clone();
                             let body = res.into_body();
@@ -83,11 +85,9 @@ pub fn get_basic_routes(cfg: &mut web::ServiceConfig) {
                             let body = String::from_utf8(body.to_vec()).unwrap();
                             let body = body.replace(
                                 r#"<base href="/" />"#,
-                                format!(r#"<base href="{}" />"#, prefix).as_str(),
+                                &format!(r#"<base href="{prefix}" />"#),
                             );
                             Ok(ServiceResponse::new(req, HttpResponse::Ok().body(body)))
-                        } else {
-                            res
                         }
                     })
                 })

--- a/src/infra/cache/stats.rs
+++ b/src/infra/cache/stats.rs
@@ -31,16 +31,13 @@ pub fn get_stats() -> DashMap<String, StreamStats> {
 
 #[inline]
 pub fn get_stream_stats(org_id: &str, stream_name: &str, stream_type: StreamType) -> StreamStats {
-    let key = format!("{}/{}/{}", org_id, stream_type, stream_name);
-    match STATS.get(&key).map(|v| *v.value()) {
-        Some(v) => v,
-        None => StreamStats::default(),
-    }
+    let key = format!("{org_id}/{stream_type}/{stream_name}");
+    STATS.get(&key).map(|v| *v.value()).unwrap_or_default()
 }
 
 #[inline]
 pub fn remove_stream_stats(org_id: &str, stream_name: &str, stream_type: StreamType) {
-    let key = format!("{}/{}/{}", org_id, stream_type, stream_name);
+    let key = format!("{org_id}/{stream_type}/{stream_name}");
     STATS.remove(&key);
 }
 
@@ -51,7 +48,7 @@ pub fn set_stream_stats(
     stream_type: StreamType,
     val: StreamStats,
 ) {
-    let key = format!("{}/{}/{}", org_id, stream_type, stream_name);
+    let key = format!("{org_id}/{stream_type}/{stream_name}");
     STATS.insert(key, val);
 }
 
@@ -69,7 +66,7 @@ pub fn incr_stream_stats(key: &str, val: FileMeta) -> Result<(), anyhow::Error> 
     let org_id = columns[1];
     let stream_type = columns[2];
     let stream_name = columns[3];
-    let key = format!("{}/{}/{}", org_id, stream_type, stream_name);
+    let key = format!("{org_id}/{stream_type}/{stream_name}");
     let mut stats = STATS.entry(key).or_default();
     if val.records == 0 {
         return Ok(());
@@ -102,7 +99,7 @@ pub fn decr_stream_stats(key: &str, val: FileMeta) -> Result<(), anyhow::Error> 
     let org_id = columns[1];
     let stream_type = columns[2];
     let stream_name = columns[3];
-    let key = format!("{}/{}/{}", org_id, stream_type, stream_name);
+    let key = format!("{org_id}/{stream_type}/{stream_name}");
     if !STATS.contains_key(&key) {
         return Ok(());
     }
@@ -122,7 +119,7 @@ pub fn reset_stream_stats(
     stream_type: StreamType,
     val: FileMeta,
 ) -> Result<(), anyhow::Error> {
-    let key = format!("{}/{}/{}", org_id, stream_type, stream_name);
+    let key = format!("{org_id}/{stream_type}/{stream_name}");
     if !STATS.contains_key(&key) {
         return Ok(());
     }
@@ -133,7 +130,6 @@ pub fn reset_stream_stats(
     if val.max_ts != 0 {
         stats.doc_time_max = val.max_ts;
     }
-
     Ok(())
 }
 

--- a/src/infra/cluster.rs
+++ b/src/infra/cluster.rs
@@ -78,7 +78,7 @@ impl FromStr for Role {
             "compactor" => Ok(Role::Compactor),
             "router" => Ok(Role::Router),
             "alertmanager" => Ok(Role::AlertManager),
-            _ => Err(format!("Invalid cluster role: {}", s)),
+            _ => Err(format!("Invalid cluster role: {s}")),
         }
     }
 }

--- a/src/infra/config.rs
+++ b/src/infra/config.rs
@@ -308,27 +308,27 @@ pub fn init() -> Config {
 
     // check common config
     if let Err(e) = check_common_config(&mut cfg) {
-        panic!("common config error: {}", e);
+        panic!("common config error: {e}");
     }
 
     // check data path config
     if let Err(e) = check_path_config(&mut cfg) {
-        panic!("data path config error: {}", e);
+        panic!("data path config error: {e}");
     }
 
     // check memeory cache
     if let Err(e) = check_memory_cache_config(&mut cfg) {
-        panic!("memory cache config error: {}", e);
+        panic!("memory cache config error: {e}");
     }
 
     // check etcd config
     if let Err(e) = check_etcd_config(&mut cfg) {
-        panic!("etcd config error: {}", e);
+        panic!("etcd config error: {e}");
     }
 
     // check s3 config
     if let Err(e) = check_s3_config(&mut cfg) {
-        panic!("s3 config error: {}", e);
+        panic!("s3 config error: {e}");
     }
     cfg
 }

--- a/src/infra/db/etcd.rs
+++ b/src/infra/db/etcd.rs
@@ -564,7 +564,6 @@ impl Locker {
                 }
                 Err(err) => {
                     last_err = Some(err.to_string());
-                    // log::error!("get lock error: {}, key: {}", err, self.key);
                     if !err.to_string().contains("Timeout expired") {
                         break;
                     }
@@ -572,7 +571,7 @@ impl Locker {
             };
         }
         if let Some(err) = last_err {
-            return Err(Error::Message(format!("etcd connect error: {}", err)));
+            return Err(Error::Message(format!("etcd connect error: {err}")));
         }
         Ok(())
     }

--- a/src/infra/errors.rs
+++ b/src/infra/errors.rs
@@ -94,18 +94,18 @@ impl ErrorCodes {
             ErrorCodes::ServerInternalError(_) => "Server Internal Error".to_string(),
             ErrorCodes::SearchSQLNotValid(_) => "Search SQL not valid".to_string(),
             ErrorCodes::SearchStreamNotFound(stream) => {
-                format!("Search stream not found: {}", stream)
+                format!("Search stream not found: {stream}")
             }
             ErrorCodes::FullTextSearchFieldNotFound => {
                 "Full text search field not found".to_string()
             }
-            ErrorCodes::SearchFieldNotFound(field) => format!("Search field not found: {}", field),
+            ErrorCodes::SearchFieldNotFound(field) => format!("Search field not found: {field}"),
             ErrorCodes::SearchFunctionNotDefined(func) => {
-                format!("Search function not defined: {}", func)
+                format!("Search function not defined: {func}")
             }
             ErrorCodes::SearchParquetFileNotFound => "Search parquet file not found".to_string(),
             ErrorCodes::SearchFieldHasNoCompatibleDataType(field) => {
-                format!("Search field has no compatible data type: {}", field)
+                format!("Search field has no compatible data type: {field}")
             }
             ErrorCodes::SearchSQLExecuteError(_) => "Search SQL execute error".to_string(),
         }

--- a/src/infra/file_lock.rs
+++ b/src/infra/file_lock.rs
@@ -115,7 +115,7 @@ impl Locker {
         stream_type: StreamType,
         key: &str,
     ) -> Option<Arc<RwFile>> {
-        let full_key = format!("{}_{}_{}_{}", org_id, stream_name, stream_type, key);
+        let full_key = format!("{org_id}_{stream_name}_{stream_type}_{key}");
         let file = match self
             .data
             .get(thread_id)
@@ -156,7 +156,7 @@ impl Locker {
         key: &str,
         use_cache: bool,
     ) -> Arc<RwFile> {
-        let full_key = format!("{}_{}_{}_{}", org_id, stream_name, stream_type, key);
+        let full_key = format!("{org_id}_{stream_name}_{stream_type}_{key}");
         let file = Arc::new(RwFile::new(
             thread_id,
             org_id,
@@ -215,8 +215,8 @@ impl RwFile {
         use_cache: bool,
     ) -> RwFile {
         let mut dir_path = format!(
-            "{}files/{}/{}/{}/",
-            &CONFIG.common.data_wal_dir, org_id, stream_type, stream_name
+            "{}files/{org_id}/{stream_type}/{stream_name}/",
+            &CONFIG.common.data_wal_dir
         );
         // Hack for file_list
         let file_list_prefix = "/files//file_list//";
@@ -224,11 +224,8 @@ impl RwFile {
             dir_path = dir_path.replace(file_list_prefix, "/file_list/");
         }
         let id = ider::generate();
-        let file_name = format!(
-            "{}_{}_{}{}",
-            thread_id, key, id, &CONFIG.common.file_ext_json
-        );
-        let file_path = format!("{}{}", dir_path, file_name);
+        let file_name = format!("{thread_id}_{key}_{id}{}", &CONFIG.common.file_ext_json);
+        let file_path = format!("{dir_path}{file_name}");
         std::fs::create_dir_all(&dir_path).unwrap();
 
         let (file, cache) = if use_cache {

--- a/src/infra/storage/mod.rs
+++ b/src/infra/storage/mod.rs
@@ -34,9 +34,10 @@ lazy_static! {
 }
 
 pub fn default() -> Box<dyn FileStorage> {
-    match is_local_disk_storage() {
-        true => Box::new(local::Local {}),
-        false => Box::new(s3::S3 {}),
+    if is_local_disk_storage() {
+        Box::new(local::Local {})
+    } else {
+        Box::new(s3::S3 {})
     }
 }
 
@@ -56,8 +57,8 @@ pub fn generate_partioned_file_key(
         time.format("%Y/%m/%d/%H").to_string()
     };
     (
-        format!("{}/{}/{}/{}/", org_id, stream_type, stream_name, prefix),
-        format!("{}{}", id, extn),
+        format!("{org_id}/{stream_type}/{stream_name}/{prefix}/"),
+        format!("{id}{extn}"),
     )
 }
 

--- a/src/job/metrics.rs
+++ b/src/job/metrics.rs
@@ -140,7 +140,7 @@ async fn update_metadata_metrics() -> Result<(), anyhow::Error> {
     for org_id in &orgs {
         let mut count: i64 = 0;
         for user in USERS.iter() {
-            if user.key().starts_with(format!("{}/", org_id).as_str()) {
+            if user.key().starts_with(&format!("{org_id}/")) {
                 count += 1;
             }
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -287,20 +287,20 @@ async fn cli() -> Result<bool, anyhow::Error> {
                     let mut id = 0;
                     for user in config::USERS.iter() {
                         id += 1;
-                        println!("{}\t{:?}\n{:?}", id, user.key(), user.value());
+                        println!("{id}\t{:?}\n{:?}", user.key(), user.value());
                     }
                 }
                 _ => {
-                    return Err(anyhow::anyhow!("unsupport reset component: {}", component));
+                    return Err(anyhow::anyhow!("unsupport reset component: {component}"));
                 }
             }
         }
         _ => {
-            return Err(anyhow::anyhow!("unsupport sub command: {}", name));
+            return Err(anyhow::anyhow!("unsupport sub command: {name}"));
         }
     }
 
-    println!("command {} execute succeeded", name);
+    println!("command {name} execute succeeded");
 
     Ok(true)
 }

--- a/src/meta/stream.rs
+++ b/src/meta/stream.rs
@@ -79,7 +79,7 @@ impl Serialize for StreamSettings {
         let mut state = serializer.serialize_struct("StreamSettings", 2)?;
         let mut part_keys = HashMap::new();
         for (index, key) in self.partition_keys.iter().enumerate() {
-            part_keys.insert(format!("L{}", index), key.to_string());
+            part_keys.insert(format!("L{index}"), key.to_string());
         }
         state.serialize_field("partition_keys", &part_keys)?;
         state.serialize_field("full_text_search_keys", &self.full_text_search_keys)?;

--- a/src/meta/user.rs
+++ b/src/meta/user.rs
@@ -61,34 +61,34 @@ pub struct DBUser {
     pub password: String,
     #[serde(default)]
     pub salt: String,
-    //#[serde(skip_serializing_if = "Vec::is_empty")]
     pub organizations: Vec<UserOrg>,
 }
 
 impl DBUser {
     pub fn get_user(&self, org_id: String) -> Option<User> {
         if self.organizations.is_empty() {
-            None
-        } else {
-            let mut local = self.clone();
-            local.organizations.retain(|org| org.name.eq(&org_id));
-            if local.organizations.is_empty() {
-                None
-            } else {
-                let org = local.organizations.first().unwrap();
-                Some(User {
-                    email: local.email,
-                    first_name: local.first_name,
-                    last_name: local.last_name,
-                    password: local.password,
-                    role: org.role.clone(),
-                    org: org.name.clone(),
-                    token: org.token.clone(),
-                    salt: local.salt,
-                })
-            }
+            return None;
         }
+
+        let mut local = self.clone();
+        local.organizations.retain(|org| org.name.eq(&org_id));
+        if local.organizations.is_empty() {
+            return None;
+        }
+
+        let org = local.organizations.first().unwrap();
+        Some(User {
+            email: local.email,
+            first_name: local.first_name,
+            last_name: local.last_name,
+            password: local.password,
+            role: org.role.clone(),
+            org: org.name.clone(),
+            token: org.token.clone(),
+            salt: local.salt,
+        })
     }
+
     pub fn get_all_users(&self) -> Vec<User> {
         let mut ret_val = vec![];
         if self.organizations.is_empty() {

--- a/src/service/compact/file_list.rs
+++ b/src/service/compact/file_list.rs
@@ -96,8 +96,7 @@ pub async fn run_delete() -> Result<(), anyhow::Error> {
     }
 
     for day in days {
-        let mut t =
-            Utc.datetime_from_str(format!("{}T00:00:00Z", day).as_str(), "%Y-%m-%dT%H:%M:%SZ")?;
+        let mut t = Utc.datetime_from_str(&format!("{day}T00:00:00Z"), "%Y-%m-%dT%H:%M:%SZ")?;
         for _hour in 0..24 {
             let offset = t.timestamp_micros();
             merge_file_list(offset).await?;
@@ -128,8 +127,7 @@ async fn merge_file_list(offset: i64) -> Result<(), anyhow::Error> {
     // get all small file list keys in this hour
     let offset = Utc.timestamp_nanos(offset * 1000);
     let offset_prefix = offset.format("/%Y/%m/%d/%H/").to_string();
-    let key = format!("file_list{}", offset_prefix);
-    // println!("merge_file_list: key: {}", key);
+    let key = format!("file_list{offset_prefix}");
     let storage = &storage::DEFAULT;
     let file_list = storage.list(&key).await?;
     if file_list.len() <= 1 {
@@ -171,7 +169,7 @@ async fn merge_file_list(offset: i64) -> Result<(), anyhow::Error> {
 
     // write new file list
     let id = ider::generate();
-    let file_name = format!("file_list{}{}.json.zst", offset_prefix, id);
+    let file_name = format!("file_list{offset_prefix}{id}.json.zst");
     let mut buf = zstd::Encoder::new(Vec::new(), 3)?;
     let mut has_content = false;
     for (_, item) in filter_file_keys.iter() {

--- a/src/service/compact/merge.rs
+++ b/src/service/compact/merge.rs
@@ -50,7 +50,7 @@ pub async fn merge_by_stream(
     let mut locker = None;
     if !CONFIG.common.local_mode {
         // get a cluster lock for compactor stream
-        let lock_key = format!("compactor/files/{}/{}/{}", org_id, stream_type, stream_name);
+        let lock_key = format!("compactor/files/{org_id}/{stream_type}/{stream_name}");
         let mut lock = etcd::Locker::new(&lock_key);
         if lock.lock(CONFIG.etcd.command_timeout).await.is_err() {
             return Ok(()); // lock failed, just skip
@@ -392,7 +392,7 @@ async fn merge_files(
     new_file_meta.compressed_size = buf.len() as u64;
 
     let id = ider::generate();
-    let new_file_key = format!("{}/{}{}", prefix, id, &CONFIG.common.file_ext_parquet);
+    let new_file_key = format!("{prefix}/{id}{}", &CONFIG.common.file_ext_parquet);
 
     log::info!(
         "[COMPACT] merge file succeeded, new file: {}, orginal_size: {}, compressed_size: {}",

--- a/src/service/db/alerts/templates.rs
+++ b/src/service/db/alerts/templates.rs
@@ -7,8 +7,8 @@ use crate::meta::alert::DestinationTemplate;
 use crate::meta::organization::DEFAULT_ORG;
 
 pub async fn get(org_id: &str, name: &str) -> Result<Option<DestinationTemplate>, anyhow::Error> {
-    let map_key = format!("{}/{}", org_id, name);
-    let default_org_key = format!("{}/{}", DEFAULT_ORG, name);
+    let map_key = format!("{org_id}/{name}");
+    let default_org_key = format!("{DEFAULT_ORG}/{name}");
     let value: Option<DestinationTemplate> = if ALERTS_TEMPLATES.contains_key(&map_key)
         || ALERTS_TEMPLATES.contains_key(&default_org_key)
     {
@@ -18,11 +18,11 @@ pub async fn get(org_id: &str, name: &str) -> Result<Option<DestinationTemplate>
         }
     } else {
         let db = &crate::infra::db::DEFAULT;
-        let key = format!("/templates/{}/{}", org_id, name);
+        let key = format!("/templates/{org_id}/{name}");
         match db.get(&key).await {
             Ok(val) => json::from_slice(&val).unwrap(),
             Err(_) => {
-                let key = format!("/templates/{}/{}", DEFAULT_ORG, name);
+                let key = format!("/templates/{DEFAULT_ORG}/{name}");
                 match db.get(&key).await {
                     Ok(val) => json::from_slice(&val).unwrap(),
                     Err(_) => None,
@@ -39,46 +39,28 @@ pub async fn set(
     mut template: DestinationTemplate,
 ) -> Result<(), anyhow::Error> {
     let db = &crate::infra::db::DEFAULT;
-    if org_id.eq(DEFAULT_ORG) {
-        template.is_default = Some(true);
-    } else {
-        template.is_default = Some(false);
-    }
-    let key = format!("/templates/{}/{}", org_id, name);
-    db.put(&key, json::to_vec(&template).unwrap().into())
-        .await?;
-    Ok(())
+    template.is_default = Some(org_id == DEFAULT_ORG);
+    let key = format!("/templates/{org_id}/{name}");
+    Ok(db
+        .put(&key, json::to_vec(&template).unwrap().into())
+        .await?)
 }
 
 pub async fn delete(org_id: &str, name: &str) -> Result<(), anyhow::Error> {
     let db = &crate::infra::db::DEFAULT;
-    let key = format!("/templates/{}/{}", org_id, name);
-    match db.delete(&key, false).await {
-        Ok(_) => Ok(()),
-        Err(e) => Err(anyhow::anyhow!(e)),
-    }
+    let key = format!("/templates/{org_id}/{name}");
+    Ok(db.delete(&key, false).await?)
 }
 
 pub async fn list(org_id: &str) -> Result<Vec<DestinationTemplate>, anyhow::Error> {
-    let mut temp_list: Vec<DestinationTemplate> = Vec::new();
-
-    for template in ALERTS_TEMPLATES.iter() {
-        if template.key().starts_with(&format!("{}/", org_id))
-            || template.key().starts_with(&format!("{}/", DEFAULT_ORG))
-        {
-            temp_list.push(template.value().clone())
-        }
-    }
-
-    /* let db = &crate::infra::db::DEFAULT;
-    let key = format!("/templates/{}", org_id);
-    let ret = db.list_values(&key).await?;
-    let mut temp_list: Vec<DestinationTemplate> = Vec::new();
-    for item_value in ret {
-        let json_val = json::from_slice(&item_value).unwrap();
-        temp_list.push(json_val)
-    } */
-    Ok(temp_list)
+    Ok(ALERTS_TEMPLATES
+        .iter()
+        .filter_map(|template| {
+            let k = template.key();
+            (k.starts_with(&format!("{org_id}/")) || k.starts_with(&format!("{DEFAULT_ORG}/")))
+                .then(|| template.value().clone())
+        })
+        .collect())
 }
 
 pub async fn watch() -> Result<(), anyhow::Error> {

--- a/src/service/db/compact/file_list.rs
+++ b/src/service/db/compact/file_list.rs
@@ -32,14 +32,14 @@ pub async fn set_offset(offset: i64) -> Result<(), anyhow::Error> {
 
 pub async fn set_delete(key: &str) -> Result<(), anyhow::Error> {
     let db = &crate::infra::db::DEFAULT;
-    let key = format!("/compact/file_list/delete/{}", key);
+    let key = format!("/compact/file_list/delete/{key}");
     db.put(&key, "OK".into()).await?;
     Ok(())
 }
 
 pub async fn del_delete(key: &str) -> Result<(), anyhow::Error> {
     let db = &crate::infra::db::DEFAULT;
-    let key = format!("/compact/file_list/delete/{}", key);
+    let key = format!("/compact/file_list/delete/{key}");
     if let Err(e) = db.delete(&key, false).await {
         if !e.to_string().contains("not exists") {
             return Err(anyhow::anyhow!(e));

--- a/src/service/db/dashboard.rs
+++ b/src/service/db/dashboard.rs
@@ -18,35 +18,30 @@ use crate::meta::dashboards::Dashboard;
 
 pub async fn get(org_id: &str, name: &str) -> Result<Option<Dashboard>, anyhow::Error> {
     let db = &crate::infra::db::DEFAULT;
-    let key = format!("/dashboard/{}/{}", org_id, name);
+    let key = format!("/dashboard/{org_id}/{name}");
     let ret = db.get(&key).await?;
     let details = String::from_utf8(ret.to_vec()).unwrap();
-    let value = Some(Dashboard {
+    Ok(Some(Dashboard {
         name: name.to_string(),
         details,
-    });
-    Ok(value)
+    }))
 }
 
 pub async fn set(org_id: &str, name: &str, details: &str) -> Result<(), anyhow::Error> {
     let db = &crate::infra::db::DEFAULT;
-    let key = format!("/dashboard/{}/{}", org_id, name);
-    db.put(&key, Bytes::from(details.to_string())).await?;
-    Ok(())
+    let key = format!("/dashboard/{org_id}/{name}");
+    Ok(db.put(&key, Bytes::from(details.to_string())).await?)
 }
 
 pub async fn delete(org_id: &str, name: &str) -> Result<(), anyhow::Error> {
     let db = &crate::infra::db::DEFAULT;
-    let key = format!("/dashboard/{}/{}", org_id, name);
-    match db.delete(&key, false).await {
-        Ok(_) => Ok(()),
-        Err(e) => Err(anyhow::anyhow!(e)),
-    }
+    let key = format!("/dashboard/{org_id}/{name}");
+    Ok(db.delete(&key, false).await?)
 }
 
 pub async fn list(org_id: &str) -> Result<Vec<Dashboard>, anyhow::Error> {
     let db = &crate::infra::db::DEFAULT;
-    let key = format!("/dashboard/{}/", org_id);
+    let key = format!("/dashboard/{org_id}/");
     let ret = db.list(&key).await?;
     let mut udf_list: Vec<Dashboard> = Vec::new();
     for (item_key, item_value) in ret {

--- a/src/service/db/mod.rs
+++ b/src/service/db/mod.rs
@@ -37,16 +37,8 @@ pub async fn set_prom_cluster_info(
     members: Vec<String>,
 ) -> Result<(), anyhow::Error> {
     let db = &crate::infra::db::DEFAULT;
-    let key = format!("/metrics_members/{}", cluster);
-    let mem_list = members
-        .into_iter()
-        .map(|val| format!("{},", val))
-        .collect::<String>();
-    let members_list = mem_list.strip_suffix(',').unwrap();
-    match db.put(&key, Bytes::from(members_list.to_string())).await {
-        Ok(_) => Ok(()),
-        Err(e) => Err(anyhow::anyhow!(e)),
-    }
+    let key = format!("/metrics_members/{cluster}");
+    Ok(db.put(&key, Bytes::from(members.join(","))).await?)
 }
 
 pub async fn set_prom_cluster_leader(
@@ -54,11 +46,8 @@ pub async fn set_prom_cluster_leader(
     leader: &ClusterLeader,
 ) -> Result<(), anyhow::Error> {
     let db = &crate::infra::db::DEFAULT;
-    let key = format!("/metrics_leader/{}", cluster);
-    match db.put(&key, json::to_vec(&leader).unwrap().into()).await {
-        Ok(_) => Ok(()),
-        Err(e) => Err(anyhow::anyhow!(e)),
-    }
+    let key = format!("/metrics_leader/{cluster}");
+    Ok(db.put(&key, json::to_vec(&leader).unwrap().into()).await?)
 }
 
 pub async fn watch_prom_cluster_leader() -> Result<(), anyhow::Error> {

--- a/src/service/logs/bulk.rs
+++ b/src/service/logs/bulk.rs
@@ -101,7 +101,7 @@ pub async fn ingest(
                 return Ok(
                     HttpResponse::InternalServerError().json(MetaHttpResponse::error(
                         http::StatusCode::INTERNAL_SERVER_ERROR.into(),
-                        format!("stream [{}] is being deleted", stream_name),
+                        format!("stream [{stream_name}] is being deleted"),
                     )),
                 );
             }
@@ -116,7 +116,6 @@ pub async fn ingest(
                 &mut stream_tansform_map,
                 &mut stream_lua_map,
                 &lua,
-                //scope,
             )
             .await;
             // End Register Transfoms for index
@@ -157,9 +156,7 @@ pub async fn ingest(
                     },
                 });
 
-            stream_file_map
-                .entry(stream_name.clone())
-                .or_insert_with(|| String::from(""));
+            stream_file_map.entry(stream_name.clone()).or_default();
         } else {
             next_line_is_data = false;
 
@@ -169,11 +166,11 @@ pub async fn ingest(
 
             //Start row based transform
             #[cfg(feature = "zo_functions")]
-            let key = format!("{}/{}/{}", &org_id, StreamType::Logs, &stream_name);
+            let key = format!("{org_id}/{}/{stream_name}", StreamType::Logs);
             #[cfg(feature = "zo_functions")]
             if let Some(transforms) = stream_tansform_map.get(&key) {
                 for trans in transforms {
-                    let func_key = format!("{}/{}", &stream_name, trans.name);
+                    let func_key = format!("{stream_name}/{}", trans.name);
                     value = crate::service::ingestion::lua_transform(
                         &lua,
                         &value,

--- a/src/service/logs/json.rs
+++ b/src/service/logs/json.rs
@@ -62,7 +62,7 @@ pub async fn ingest(
         return Ok(
             HttpResponse::InternalServerError().json(MetaHttpResponse::error(
                 http::StatusCode::INTERNAL_SERVER_ERROR.into(),
-                format!("stream [{}] is being deleted", stream_name),
+                format!("stream [{stream_name}] is being deleted"),
             )),
         );
     }
@@ -90,14 +90,14 @@ pub async fn ingest(
     #[cfg(feature = "zo_functions")]
     let mut local_tans: Vec<Transform> = vec![];
     #[cfg(feature = "zo_functions")]
-    let key = format!("{}/{}/{}", &org_id, StreamType::Logs, &stream_name);
+    let key = format!("{org_id}/{}/{stream_name}", StreamType::Logs);
     #[cfg(feature = "zo_functions")]
     if let Some(transforms) = STREAM_FUNCTIONS.get(&key) {
         local_tans = (*transforms.list).to_vec();
         local_tans.sort_by(|a, b| a.order.cmp(&b.order));
         let mut func: Function;
         for trans in &local_tans {
-            let func_key = format!("{}/{}", &stream_name, trans.name);
+            let func_key = format!("{stream_name}/{}", trans.name);
             func = crate::service::ingestion::load_lua_transform(&lua, trans.function.clone());
             stream_lua_map.insert(func_key, func.to_owned());
         }

--- a/src/service/logs/mod.rs
+++ b/src/service/logs/mod.rs
@@ -92,12 +92,9 @@ pub fn get_partition_key_record(s: &str) -> String {
 
 // generate partition key for query
 pub fn get_partition_key_query(s: &str) -> String {
-    let s = s.replace(['/', '.'], "_");
-    if s.len() > 100 {
-        s[0..100].to_string()
-    } else {
-        s
-    }
+    let mut s = s.replace(['/', '.'], "_");
+    s.truncate(100);
+    s
 }
 
 pub fn cast_to_type(mut value: Value, delta: Vec<Field>) -> Option<String> {
@@ -216,7 +213,7 @@ pub fn cast_to_type(mut value: Value, delta: Vec<Field>) -> Option<String> {
                         Err(_) => parse_error = true,
                     };
                 }
-                _ => println!("{:?}", local_val),
+                _ => println!("{local_val:?}"),
             };
         }
     }
@@ -336,15 +333,15 @@ fn get_hour_key(
 
     for key in &partition_keys {
         match local_val.get(key) {
+            None => continue,
             Some(v) => {
                 let val = if v.is_string() {
-                    format!("{}={}", key, v.as_str().unwrap())
+                    format!("{key}={}", v.as_str().unwrap())
                 } else {
-                    format!("{}={}", key, v)
+                    format!("{key}={v}")
                 };
                 hour_key.push_str(&format!("_{}", get_partition_key_record(&val)));
             }
-            None => continue,
         };
     }
     hour_key

--- a/src/service/logs/multi.rs
+++ b/src/service/logs/multi.rs
@@ -63,7 +63,7 @@ pub async fn ingest(
         return Ok(
             HttpResponse::InternalServerError().json(MetaHttpResponse::error(
                 http::StatusCode::INTERNAL_SERVER_ERROR.into(),
-                format!("stream [{}] is being deleted", stream_name),
+                format!("stream [{stream_name}] is being deleted"),
             )),
         );
     }

--- a/src/service/metrics/mod.rs
+++ b/src/service/metrics/mod.rs
@@ -216,7 +216,7 @@ pub async fn prometheus_write_proto(
                 return Ok(HttpResponse::InternalServerError().json(
                     meta::http::HttpResponse::error(
                         http::StatusCode::INTERNAL_SERVER_ERROR.into(),
-                        format!("stream [{}] is being deleted", metric_name),
+                        format!("stream [{metric_name}] is being deleted"),
                     ),
                 ));
             }

--- a/src/service/search.rs
+++ b/src/service/search.rs
@@ -72,17 +72,7 @@ pub async fn search(
     })
     .join();
 
-    if result.is_err() {
-        let err = result.err();
-        return Err(Error::ErrorCode(ErrorCodes::ServerInternalError(format!(
-            "{:?}",
-            err
-        ))));
-    }
-    match result.unwrap() {
-        Ok(res) => Ok(res),
-        Err(err) => Err(err),
-    }
+    result.map_err(|err| Error::ErrorCode(ErrorCodes::ServerInternalError(format!("{err:?}"))))?
 }
 
 #[tracing::instrument(name = "service:search:local:enter", skip(req))]
@@ -627,7 +617,7 @@ fn handle_metrics_response(sources: Vec<json::Value>) -> Vec<json::Value> {
         let mut key = Vec::with_capacity(fields.len());
         fields.iter().for_each(|(k, v)| {
             if !k.eq(&CONFIG.common.time_stamp_col) && !k.eq("value") {
-                key.push(format!("{}_{}", k, v));
+                key.push(format!("{k}_{v}"));
             }
         });
         let key = key.join("_");

--- a/src/service/search/cache.rs
+++ b/src/service/search/cache.rs
@@ -122,8 +122,8 @@ pub async fn search(
 #[inline]
 async fn get_file_list(sql: &Sql, stream_type: meta::StreamType) -> Result<Vec<String>, Error> {
     let pattern = format!(
-        "{}/files/{}/{}/{}/*.json",
-        &CONFIG.common.data_wal_dir, &sql.org_id, stream_type, &sql.stream_name
+        "{}/files/{}/{stream_type}/{}/*.json",
+        &CONFIG.common.data_wal_dir, &sql.org_id, &sql.stream_name
     );
     let files = scan_files(&pattern);
 
@@ -141,9 +141,9 @@ async fn get_file_list(sql: &Sql, stream_type: meta::StreamType) -> Result<Vec<S
         let file_path = file.parent().unwrap().to_str().unwrap().replace('\\', "/");
         let file_name = file.file_name().unwrap().to_str().unwrap();
         let file_name = file_name.replace('_', "/");
-        let source_file = format!("{}/{}", file_path, file_name);
+        let source_file = format!("{file_path}/{file_name}");
         if sql.match_source(&source_file, false, stream_type).await {
-            result.push(format!("{}{}", &CONFIG.common.data_wal_dir, local_file));
+            result.push(format!("{}{local_file}", &CONFIG.common.data_wal_dir));
         }
     }
     Ok(result)

--- a/src/service/search/datafusion/regexp_udf.rs
+++ b/src/service/search/datafusion/regexp_udf.rs
@@ -76,22 +76,20 @@ pub fn regex_match_expr_impl(matches: bool) -> ScalarFunctionImplementation {
             // second arg was array (not constant)
             ColumnarValue::Array(_) => {
                 return Err(DataFusionError::NotImplemented(format!(
-                    "regex_match({}) with non scalar patterns not yet implemented",
-                    matches
+                    "regex_match({matches}) with non scalar patterns not yet implemented"
                 )))
             }
             ColumnarValue::Scalar(ScalarValue::Utf8(pattern)) => pattern,
             ColumnarValue::Scalar(arg) => {
                 return Err(DataFusionError::Internal(format!(
-                    "Expected string pattern to regex match({}), got: {:?}",
-                    matches, arg
+                    "Expected string pattern to regex_match({matches}), got: {arg:?}"
                 )))
             }
         };
 
         let pattern = pattern.as_ref().ok_or_else(|| {
             DataFusionError::NotImplemented(
-                "NULL patterns not supported in regex match".to_string(),
+                "NULL patterns not supported in regex_match".to_string(),
             )
         })?;
 
@@ -100,7 +98,7 @@ pub fn regex_match_expr_impl(matches: bool) -> ScalarFunctionImplementation {
         let pattern = clean_non_meta_escapes(pattern);
 
         let pattern = regex::Regex::new(&pattern).map_err(|e| {
-            DataFusionError::Internal(format!("error compiling regex pattern: {}", e))
+            DataFusionError::Internal(format!("error compiling regex pattern: {e}"))
         })?;
 
         match &args[0] {
@@ -121,8 +119,7 @@ pub fn regex_match_expr_impl(matches: bool) -> ScalarFunctionImplementation {
                 Ok(ColumnarValue::Scalar(ScalarValue::Boolean(res)))
             }
             ColumnarValue::Scalar(v) => Err(DataFusionError::Internal(format!(
-                "regex_match({}) expected first argument to be utf8, got ('{}')",
-                matches, v
+                "regex_match({matches}) expected first argument to be utf8, got ('{v}')"
             ))),
         }
     };

--- a/src/service/search/storage.rs
+++ b/src/service/search/storage.rs
@@ -173,7 +173,7 @@ pub async fn search(
         );
         let sql = sql.clone();
         let session = meta::search::Session {
-            id: format!("{}-{}", session_id, ver),
+            id: format!("{session_id}-{ver}"),
             data_type: SessionType::Remote,
         };
         // cacluate the diff between latest schema and group schema

--- a/src/service/stream.rs
+++ b/src/service/stream.rs
@@ -174,7 +174,7 @@ pub async fn save_stream_settings(
         return Ok(
             HttpResponse::InternalServerError().json(MetaHttpResponse::error(
                 http::StatusCode::INTERNAL_SERVER_ERROR.into(),
-                format!("stream [{}] is being deleted", stream_name),
+                format!("stream [{stream_name}] is being deleted"),
             )),
         );
     }
@@ -226,7 +226,7 @@ pub async fn delete_stream(
         return Ok(
             HttpResponse::InternalServerError().json(MetaHttpResponse::error(
                 StatusCode::INTERNAL_SERVER_ERROR.into(),
-                format!("failed to delete stream: {}", e),
+                format!("failed to delete stream: {e}"),
             )),
         );
     }
@@ -236,13 +236,13 @@ pub async fn delete_stream(
         return Ok(
             HttpResponse::InternalServerError().json(MetaHttpResponse::error(
                 StatusCode::INTERNAL_SERVER_ERROR.into(),
-                format!("failed to delete stream: {}", e),
+                format!("failed to delete stream: {e}"),
             )),
         );
     }
 
     // delete stream schema cache
-    let key = format!("{}/{}/{}", org_id, stream_type, stream_name);
+    let key = format!("{org_id}/{stream_type}/{stream_name}");
     STREAM_SCHEMAS.remove(&key);
 
     // delete stream stats cache
@@ -253,7 +253,7 @@ pub async fn delete_stream(
         return Ok(
             HttpResponse::InternalServerError().json(MetaHttpResponse::error(
                 StatusCode::INTERNAL_SERVER_ERROR.into(),
-                format!("failed to delete stream: {}", e),
+                format!("failed to delete stream: {e}"),
             )),
         );
     };

--- a/src/service/users.rs
+++ b/src/service/users.rs
@@ -264,8 +264,8 @@ pub async fn add_user_to_org(
 
 pub async fn get_user(org_id: Option<&str>, name: &str) -> Option<User> {
     let key = match org_id {
-        Some(local_org) => format!("{}/{}", local_org, name),
-        None => format!("{}/{}", DEFAULT_ORG, name),
+        Some(local_org) => format!("{local_org}/{name}"),
+        None => format!("{DEFAULT_ORG}/{name}"),
     };
     let user = USERS.get(&key);
     match user {
@@ -289,7 +289,7 @@ pub async fn get_user(org_id: Option<&str>, name: &str) -> Option<User> {
 pub async fn list_users(org_id: &str) -> Result<HttpResponse, Error> {
     let mut user_list: Vec<UserResponse> = vec![];
     for user in USERS.iter() {
-        if user.key().starts_with(format!("{}/", org_id).as_str()) {
+        if user.key().starts_with(&format!("{org_id}/")) {
             user_list.push(UserResponse {
                 email: user.value().email.clone(),
                 role: user.value().role.clone(),
@@ -316,7 +316,7 @@ pub async fn remove_user_from_org(org_id: &str, email_id: &str) -> Result<HttpRe
                     let resp = db::user::set(user).await;
                     //special case as we cache flattened user struct
                     if resp.is_ok() {
-                        USERS.remove(&format!("{}/{}", org_id, email_id));
+                        USERS.remove(&format!("{org_id}/{email_id}"));
                     }
                 }
                 Ok(HttpResponse::Ok().json(MetaHttpResponse::message(


### PR DESCRIPTION
I got carried away and overdid refactoring. The resulting patch is difficult to review in several places. I do beg your (reviewers') pardon and brace myself for a request to divide the patch into several commits with clear topics (e.g., 1 - inline format arguments; 2 - replace loops with iterators, etc.).