### PR TITLE
feat: add storage operation times

### DIFF
--- a/src/infra/metrics.rs
+++ b/src/infra/metrics.rs
@@ -160,7 +160,7 @@ lazy_static! {
         &["organization", "stream", "stream_type"],
     ).expect("Metric created");
     pub static ref STORAGE_TIME: CounterVec = CounterVec::new(
-      HistogramOpts::new("storage_time", "Storage response time")
+        Opts::new("storage_time", "Storage response time")
           .namespace(NAMESPACE)
           .const_labels(create_const_labels()),
           &["organization", "stream", "stream_type", "method_type"],

--- a/src/infra/metrics.rs
+++ b/src/infra/metrics.rs
@@ -310,6 +310,9 @@ fn register_metrics(registry: &Registry) {
     registry
         .register(Box::new(STORAGE_READ_BYTES.clone()))
         .expect("Metric registered");
+    registry
+        .register(Box::new(STORAGE_TIME.clone()))
+        .expect("Metric registered");
 
     // metadata stats
     registry

--- a/src/infra/metrics.rs
+++ b/src/infra/metrics.rs
@@ -159,6 +159,12 @@ lazy_static! {
             .const_labels(create_const_labels()),
         &["organization", "stream", "stream_type"],
     ).expect("Metric created");
+    pub static ref STORAGE_TIME: HistogramVec = HistogramVec::new(
+      HistogramOpts::new("storage_time", "Storage response time")
+          .namespace(NAMESPACE)
+          .const_labels(create_const_labels()),
+          &["organization", "stream", "stream_type", "method_type"],
+    ).expect("Metric created");
 
     // metadata stats
     pub static ref META_STORAGE_BYTES: IntGaugeVec = IntGaugeVec::new(

--- a/src/infra/metrics.rs
+++ b/src/infra/metrics.rs
@@ -159,7 +159,7 @@ lazy_static! {
             .const_labels(create_const_labels()),
         &["organization", "stream", "stream_type"],
     ).expect("Metric created");
-    pub static ref STORAGE_TIME: HistogramVec = HistogramVec::new(
+    pub static ref STORAGE_TIME: CounterVec = CounterVec::new(
       HistogramOpts::new("storage_time", "Storage response time")
           .namespace(NAMESPACE)
           .const_labels(create_const_labels()),

--- a/src/infra/storage/local.rs
+++ b/src/infra/storage/local.rs
@@ -59,8 +59,8 @@ impl FileStorage for Local {
 
             let time = start.elapsed().as_secs_f64();
             metrics::STORAGE_TIME
-            .with_label_values(&[columns[1], columns[3], columns[2], "get"])
-            .inc_by(time);
+                .with_label_values(&[columns[1], columns[3], columns[2], "get"])
+                .inc_by(time);
         }
 
         Ok(bytes::Bytes::from(data))
@@ -68,6 +68,7 @@ impl FileStorage for Local {
 
     async fn put(&self, file: &str, data: bytes::Bytes) -> Result<(), anyhow::Error> {
         let start = Instant::now();
+        let root_path = Path::new(&CONFIG.common.data_stream_dir).to_str().unwrap();
         let file = format!("{}{}", CONFIG.common.data_stream_dir, file);
         let file_path = Path::new(&file);
         fs::create_dir_all(file_path.parent().unwrap()).unwrap();
@@ -75,6 +76,7 @@ impl FileStorage for Local {
         match put_file_contents(&file, &data) {
             Ok(_) => {
                 // metrics
+                let file = file[root_path.len()..].to_string();
                 let columns = file.split('/').collect::<Vec<&str>>();
                 if columns[0].eq("files") {
                     metrics::STORAGE_WRITE_BYTES
@@ -83,8 +85,8 @@ impl FileStorage for Local {
 
                     let time = start.elapsed().as_secs_f64();
                     metrics::STORAGE_TIME
-                    .with_label_values(&[columns[1], columns[3], columns[2], "put"])
-                    .inc_by(time);
+                        .with_label_values(&[columns[1], columns[3], columns[2], "put"])
+                        .inc_by(time);
                 }
                 Ok(())
             }
@@ -96,12 +98,34 @@ impl FileStorage for Local {
         if files.is_empty() {
             return Ok(());
         }
+
+        let start = Instant::now();
+        let mut columns: Option<Vec<&str>> = Default::default();
+
         for file in files {
+            if columns.is_none() {
+                let _columns = file.split('/').collect::<Vec<&str>>();
+                if _columns[0].eq("files") {
+                    columns = Some(_columns);
+                }
+            }
+
             let file = format!("{}{}", CONFIG.common.data_stream_dir, file);
+
             if let Err(e) = fs::remove_file(file) {
                 return Err(anyhow::anyhow!(e));
             }
         }
+
+        if let Some(columns) = columns {
+            if columns[0].eq("files") {
+                let time = start.elapsed().as_secs_f64();
+                metrics::STORAGE_TIME
+                    .with_label_values(&[columns[1], columns[3], columns[2], "del"])
+                    .inc_by(time);
+            }
+        }
+
         Ok(())
     }
 }

--- a/src/infra/storage/local.rs
+++ b/src/infra/storage/local.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 use async_trait::async_trait;
-use std::{fs, io::Read, path::Path};
+use std::{fs, io::Read, path::Path, time::Instant};
 
 use super::FileStorage;
 use crate::common::file::put_file_contents;
@@ -59,7 +59,7 @@ impl FileStorage for Local {
 
             let time = start.elapsed().as_secs_f64();
             metrics::STORAGE_TIME
-            .with_label_values(&[columns[1], columns[3], columns[2]], 'get')
+            .with_label_values(&[columns[1], columns[3], columns[2], "get"])
             .inc_by(time);
         }
 
@@ -83,7 +83,7 @@ impl FileStorage for Local {
 
                     let time = start.elapsed().as_secs_f64();
                     metrics::STORAGE_TIME
-                    .with_label_values(&[columns[1], columns[3], columns[2]], 'put')
+                    .with_label_values(&[columns[1], columns[3], columns[2], "put"])
                     .inc_by(time);
                 }
                 Ok(())

--- a/src/infra/storage/s3.rs
+++ b/src/infra/storage/s3.rs
@@ -90,7 +90,7 @@ impl FileStorage for S3 {
 
         let time = instant.elapsed().as_secs_f64();
         metrics::STORAGE_TIME
-        .with_label_values(&[columns[1], columns[3], columns[2]], 'get')
+        .with_label_values(&[columns[1], columns[3], columns[2]], 'list')
         .observe(time);
 
         Ok(files)

--- a/src/infra/storage/s3.rs
+++ b/src/infra/storage/s3.rs
@@ -227,7 +227,7 @@ impl FileStorage for S3 {
                                         && !file.starts_with(&CONFIG.s3.bucket_prefix)
                                     {
                                         format!("{}{}", CONFIG.s3.bucket_prefix, file)
-                                    } else { 
+                                    } else {
                                         file.to_string()
                                     };
                                     ObjectIdentifier::builder().set_key(Some(key)).build()

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -1133,7 +1133,7 @@ mod tests {
 
     async fn e2e_post_alert() {
         let auth = setup();
-        let body_str = r#"{                              
+        let body_str = r#"{
                                 "condition": {
                                     "column": "country",
                                     "operator": "=",
@@ -1145,7 +1145,7 @@ mod tests {
                                 "destination":"slack",
                                 "context_attributes":{
                                     "app_name":"App1"
-                                } 
+                                }
                             }"#;
         let app = test::init_service(
             App::new()


### PR DESCRIPTION
- Adds support for the metric `STORAGE_TIME` for the Block and Local Storage operations  `put`, `get`, `del`
- Fix local put metrics, because of the full path it was never matching the `files` condition 
https://github.com/zinclabs/zincobserve/pull/493/commits/7c5df89d3a582e491ad4783cc8c3f645f9c4fe16#diff-f1a1da44d7bdd8180e86b1c3b2b39b0e8f853def40063173558f019bca07d3b8R71