### PR TITLE
chore: compare types, not strings

### DIFF
--- a/src/infra/errors.rs
+++ b/src/infra/errors.rs
@@ -46,7 +46,7 @@ pub enum Error {
 
 #[derive(ThisError, Debug)]
 pub enum DbError {
-    #[error("key:{0} not exists")]
+    #[error("key {0} does not exist")]
     KeyNotExists(String),
 }
 
@@ -191,14 +191,22 @@ impl ErrorCodes {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use expect_test::expect;
 
     #[test]
     fn test_error() {
-        let err = Error::Message("test".to_string());
-        assert_eq!(err.to_string(), "Error# test");
+        let err = Error::Message("Ni! Try again.".to_string());
+        expect![["Error# Ni! Try again."]].assert_eq(&err.to_string());
 
-        let err = Error::from(DbError::KeyNotExists("test".to_string()));
-        assert_eq!(err.to_string(), "DbError# key:test not exists");
-        assert_eq!(format!("{:?}", err), "DbError(KeyNotExists(\"test\"))");
+        let err = Error::from(DbError::KeyNotExists("/another/shrubbery".to_string()));
+        expect![["DbError# key /another/shrubbery does not exist"]].assert_eq(&err.to_string());
+        expect![[r#"
+            DbError(
+                KeyNotExists(
+                    "/another/shrubbery",
+                ),
+            )
+        "#]]
+        .assert_debug_eq(&err);
     }
 }

--- a/src/service/db/alerts/mod.rs
+++ b/src/service/db/alerts/mod.rs
@@ -168,6 +168,5 @@ pub async fn cache() -> Result<(), anyhow::Error> {
 pub async fn reset() -> Result<(), anyhow::Error> {
     let db = &crate::infra::db::DEFAULT;
     let key = "/alerts/";
-    db.delete(key, true).await?;
-    Ok(())
+    Ok(db.delete(key, true).await?)
 }

--- a/src/service/db/compact/delete.rs
+++ b/src/service/db/compact/delete.rs
@@ -78,12 +78,9 @@ pub async fn delete_stream_done(
 ) -> Result<(), anyhow::Error> {
     let db = &crate::infra::db::DEFAULT;
     let key = mk_key(org_id, stream_type, stream_name, date_range);
-    let db_key = format!("/compact/delete/{key}");
-    if let Err(e) = db.delete(&db_key, false).await {
-        if !e.to_string().contains("not exists") {
-            return Err(anyhow::anyhow!(e));
-        }
-    }
+    db.delete_if_exists(&format!("/compact/delete/{key}"), false)
+        .await
+        .map_err(|e| anyhow::anyhow!(e))?;
 
     // remove in cache
     CACHE.remove(&key);

--- a/src/service/db/compact/file_list.rs
+++ b/src/service/db/compact/file_list.rs
@@ -40,12 +40,7 @@ pub async fn set_delete(key: &str) -> Result<(), anyhow::Error> {
 pub async fn del_delete(key: &str) -> Result<(), anyhow::Error> {
     let db = &crate::infra::db::DEFAULT;
     let key = format!("/compact/file_list/delete/{key}");
-    if let Err(e) = db.delete(&key, false).await {
-        if !e.to_string().contains("not exists") {
-            return Err(anyhow::anyhow!(e));
-        }
-    }
-    Ok(())
+    db.delete_if_exists(&key, false).await.map_err(Into::into)
 }
 
 pub async fn list_delete() -> Result<Vec<String>, anyhow::Error> {

--- a/src/service/db/compact/files.rs
+++ b/src/service/db/compact/files.rs
@@ -51,12 +51,7 @@ pub async fn del_offset(
 ) -> Result<(), anyhow::Error> {
     let db = &crate::infra::db::DEFAULT;
     let key = mk_key(org_id, stream_type, stream_name);
-    if let Err(e) = db.delete(&key, false).await {
-        if !e.to_string().contains("not exists") {
-            return Err(anyhow::anyhow!(e));
-        }
-    }
-    Ok(())
+    db.delete_if_exists(&key, false).await.map_err(Into::into)
 }
 
 pub async fn list_offset() -> Result<Vec<(String, i64)>, anyhow::Error> {


### PR DESCRIPTION
This patch began with my attempt to edit `DbError::KeyNotExists` error message. That change caused `cargo test e2e` to fail. There was code that converted `crate::infra::errors::Error` to `String` and searched for a hard-coded substring. Rust compiler, however advanced, is of little help if the code is *stringly*-typed.