### PR TITLE
chore: let Serde fill omitted `Dashboard` fields

### DIFF
--- a/src/handler/http/request/dashboards/mod.rs
+++ b/src/handler/http/request/dashboards/mod.rs
@@ -33,12 +33,7 @@ use crate::{meta::dashboards::Dashboard, service::dashboards};
         description = "Dashboard details",
         example = json!({
             "title": "Network Traffic Overview",
-            "dashboardId": "",
             "description": "Traffic patterns and network performance of the infrastructure",
-            "role": "",
-            "owner": "root@example.com",
-            "created": "2023-04-11T18:28:18.658Z",
-            "panels": [],
         }),
     ),
     responses(
@@ -70,15 +65,6 @@ pub async fn create_dashboard(
     request_body(
         content = Dashboard,
         description = "Dashboard details",
-        example = json!({
-            "title": "Network Traffic Overview",
-            "dashboardId": "7051662927232892928",
-            "description": "Traffic patterns and network performance of the infrastructure",
-            "role": "",
-            "owner": "root@example.com",
-            "created": "2023-04-11T18:28:18.658Z",
-            "panels": [],
-        }),
     ),
     responses(
         (status = StatusCode::OK, description = "Dashboard updated", body = HttpResponse),

--- a/src/meta/dashboards.rs
+++ b/src/meta/dashboards.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use chrono::{DateTime, FixedOffset};
+use chrono::{DateTime, FixedOffset, Utc};
 use serde::{Deserialize, Serialize};
 use utoipa::ToSchema;
 
@@ -26,16 +26,27 @@ pub struct Dashboards {
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, ToSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct Dashboard {
+    #[serde(default)]
     pub dashboard_id: String,
     pub title: String,
     pub description: String,
+    #[serde(default)]
     pub role: String,
+    #[serde(default)]
     pub owner: String,
+    #[serde(default = "datetime_now")]
     #[schema(value_type = String, format = DateTime)]
     pub created: DateTime<FixedOffset>,
+    #[serde(default)]
     pub panels: Vec<Panel>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub layouts: Option<Vec<Layout>>,
+}
+
+fn datetime_now() -> DateTime<FixedOffset> {
+    Utc::now().with_timezone(&FixedOffset::east_opt(0).expect(
+        "BUG" // This can't possibly fail. Can it?
+    ))
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, ToSchema)]


### PR DESCRIPTION
This simplifies "Create a dashboard" API, leaving only two required fields - `title` and `description` - in the request.

