### PR TITLE
feat: format time

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -81,7 +81,7 @@ lru = "0.8.1"
 memchr = "2.5.0"
 mimalloc = { version = "0.1", default-features = false, optional = true }
 object_store = { version = "0.5.4", features = ["aws", "gcp"] }
-once_cell = "1.15.0"
+once_cell = "1.17"
 opentelemetry = { version = "0.18", features = ["rt-tokio"] }
 opentelemetry-otlp = { version = "0.11", features = [
   "http-proto",

--- a/src/infra/cache/tmpfs.rs
+++ b/src/infra/cache/tmpfs.rs
@@ -15,13 +15,12 @@
 use bytes::Bytes;
 use chrono::{DateTime, Utc};
 use dashmap::DashMap;
+use once_cell::sync::Lazy;
 
 use crate::infra::errors::*;
 
-lazy_static! {
-    pub static ref FILES: DashMap<String, File> = DashMap::new();
-    pub static ref DATA: DashMap<String, Bytes> = DashMap::new();
-}
+static FILES: Lazy<DashMap<String, File>> = Lazy::new(DashMap::new);
+static DATA: Lazy<DashMap<String, Bytes>> = Lazy::new(DashMap::new);
 
 const STRING_SIZE: usize = std::mem::size_of::<String>();
 const BYTES_SIZE: usize = std::mem::size_of::<bytes::Bytes>();

--- a/src/meta/dashboards.rs
+++ b/src/meta/dashboards.rs
@@ -45,7 +45,7 @@ pub struct Dashboard {
 
 fn datetime_now() -> DateTime<FixedOffset> {
     Utc::now().with_timezone(&FixedOffset::east_opt(0).expect(
-        "BUG" // This can't possibly fail. Can it?
+        "BUG", // This can't possibly fail. Can it?
     ))
 }
 


### PR DESCRIPTION
- [x] improve timestamp unit check
- [x] try `once_cell::sync::Lazy` instead of `lazy_static`