### PR TITLE
fix: use correct number of μs in an hour

### DIFF
--- a/src/service/search/mod.rs
+++ b/src/service/search/mod.rs
@@ -262,7 +262,7 @@ async fn search_in_cluster(req: cluster_rpc::SearchRequest) -> Result<Response, 
     )
     .await
     {
-        Ok(file_list) => match (time_max - time_min) >= 3600_1000_1000 {
+        Ok(file_list) => match (time_max - time_min) >= 3_600_000_000 {
             true => {
                 // over than 1 hour, just filter by partition key
                 let mut files = Vec::with_capacity(file_list.len());


### PR DESCRIPTION
We were off by mere 99 hours. 🤓
```
$ python3 -c 'print((360010001000 - 3600000000) // 1000000 // 3600)'
99
```