### PR TITLE
fix: logs refresh interval and chart issue

### DIFF
--- a/web/src/components/MetricLineChart.vue
+++ b/web/src/components/MetricLineChart.vue
@@ -14,7 +14,7 @@
 -->
 
 <template>
-  <div ref="plotref" id="plotly_chart" />
+  <div ref="plotref" id="metrics_plotly_chart" />
 </template>
 
 <script lang="ts">
@@ -163,7 +163,7 @@ export default defineComponent({
         "xaxis.autorange": true,
         "yaxis.autorange": true,
       };
-      if (document.getElementById("plotly_chart") != null) {
+      if (document.getElementById("metrics_plotly_chart") != null) {
         Plotly.relayout(plotref.value, update);
       }
     });
@@ -171,8 +171,8 @@ export default defineComponent({
     const reDraw = (chart: any) => {
       traces = [...chart.data];
       layout.title.text = chart.layout.title;
-      if (document.getElementById("plotly_chart") != null) {
-        Plotly.react("plotly_chart", traces, layout);
+      if (document.getElementById("metrics_plotly_chart") != null) {
+        Plotly.react("metrics_plotly_chart", traces, layout);
       }
     };
 
@@ -183,7 +183,7 @@ export default defineComponent({
         "xaxis.autorange": true,
         "yaxis.autorange": true,
       };
-      if (document.getElementById("plotly_chart") != null) {
+      if (document.getElementById("metrics_plotly_chart") != null) {
         Plotly.relayout(plotref.value, update);
       }
     };

--- a/web/src/plugins/logs/Index.vue
+++ b/web/src/plugins/logs/Index.vue
@@ -142,8 +142,7 @@
           </div>
           <div v-else>
             <h5 data-test="logs-search-error-message" class="text-center">
-              <q-icon name="warning" color="warning"
-size="10rem" /><br />{{
+              <q-icon name="warning" color="warning" size="10rem" /><br />{{
                 searchObj.data.errorMsg
               }}
             </h5>
@@ -1109,6 +1108,7 @@ export default defineComponent({
         searchObj.meta.refreshInterval > 0 &&
         router.currentRoute.value.name == "logs"
       ) {
+        clearInterval(refreshIntervalID);
         refreshIntervalID = setInterval(() => {
           runQueryFn();
         }, parseInt(searchObj.meta.refreshInterval) * 1000);


### PR DESCRIPTION
1. Previous refresh interval was not getting cleared on selecting new one.
2. Metrics chart was sometime getting rendered on logs page