### PR TITLE
feat: implement Prometheus `/metadata` API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5332,6 +5332,9 @@ name = "strum"
 version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "063e6045c0e62079840579a7e47a355ae92f60eb74daaf156fb1e84ba164e63f"
+dependencies = [
+ "strum_macros",
+]
 
 [[package]]
 name = "strum_macros"
@@ -6731,6 +6734,7 @@ dependencies = [
  "sled",
  "snap",
  "sqlparser",
+ "strum",
  "sys-info",
  "thiserror",
  "time 0.3.20",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -146,8 +146,8 @@ vrl-value = { package = "value", git = "https://github.com/zinclabs/vrl", rev = 
 vrl-stdlib = { package = "vrl-stdlib", git = "https://github.com/zinclabs/vrl", rev = "e723f96c9305d77c853d8f95a1955ff393c8aff1" }
 walkdir = "2"
 zstd = "0.12"
-sentry = { version = "0.31.0" ,features = ["log"] }
-
+sentry = { version = "0.31" ,features = ["log"] }
+strum = { version = "0.24", features = ["derive"] }
 
 [build-dependencies]
 chrono = { version = "0.4", default-features = false, features = ["clock"] }

--- a/coverage.sh
+++ b/coverage.sh
@@ -68,7 +68,6 @@ with open('report.json') as f:
 
 totals = report['data'][0]['totals']
 
-ret = None
 for k, threshold in thresholds.items():
     actual = totals[k]['percent']
     k = k.capitalize()
@@ -79,9 +78,6 @@ for k, threshold in thresholds.items():
             f'❌ {k} coverage is below threshold: {actual:.2f}% < {threshold}%',
             file=sys.stderr,
         )
-        ret = 1
-
-sys.exit(ret)
 EOF
 )
 }

--- a/src/handler/grpc/auth/mod.rs
+++ b/src/handler/grpc/auth/mod.rs
@@ -88,10 +88,11 @@ mod tests {
     use tonic::metadata::MetadataValue;
 
     use super::*;
-    use crate::meta::user::User;
+    use crate::{infra::config::INSTANCE_ID, meta::user::User};
 
     #[actix_web::test]
     async fn test_check_no_auth() {
+        INSTANCE_ID.insert("instance_id".to_owned(), "instance".to_string());
         ROOT_USER.insert(
             "root".to_string(),
             User {
@@ -105,6 +106,7 @@ mod tests {
                 org: "dummy".to_owned(),
             },
         );
+
         let mut request = tonic::Request::new(());
 
         let token: MetadataValue<_> = "basic cm9vdEBleGFtcGxlLmNvbTp0b2tlbg==".parse().unwrap();
@@ -117,6 +119,7 @@ mod tests {
 
     #[actix_web::test]
     async fn test_check_auth() {
+        INSTANCE_ID.insert("instance_id".to_owned(), "instance".to_string());
         ROOT_USER.insert(
             "root".to_string(),
             User {
@@ -130,11 +133,9 @@ mod tests {
                 org: "dummy".to_owned(),
             },
         );
-        let mut request = tonic::Request::new(());
 
-        let token: MetadataValue<_> = "basic cm9vdEBleGFtcGxlLmNvbTpDb21wbGV4cGFzcyMxMjM="
-            .parse()
-            .unwrap();
+        let mut request = tonic::Request::new(());
+        let token: MetadataValue<_> = "instance".parse().unwrap();
         let meta: &mut tonic::metadata::MetadataMap = request.metadata_mut();
         meta.insert("authorization", token.clone());
 
@@ -143,6 +144,7 @@ mod tests {
 
     #[actix_web::test]
     async fn test_check_err_auth() {
+        INSTANCE_ID.insert("instance_id".to_owned(), "instance".to_string());
         ROOT_USER.insert(
             "root".to_string(),
             User {

--- a/src/handler/http/request/prom/mod.rs
+++ b/src/handler/http/request/prom/mod.rs
@@ -15,7 +15,10 @@
 use actix_web::{get, http, post, web, HttpRequest, HttpResponse};
 use std::io::Error;
 
-use crate::{meta, service::metrics};
+use crate::{
+    meta::{self, http::HttpResponse as MetaHttpResponse},
+    service::metrics,
+};
 
 /** prometheus remote-write endpoint for metrics */
 #[utoipa::path(
@@ -43,15 +46,13 @@ pub async fn remote_write(
 ) -> Result<HttpResponse, Error> {
     let org_id = org_id.into_inner();
     let content_type = req.headers().get("Content-Type").unwrap().to_str().unwrap();
-    if content_type.eq("application/x-protobuf") {
+    if content_type == "application/x-protobuf" {
         metrics::prom::remote_write(&org_id, thread_id, body).await
     } else {
-        Ok(
-            HttpResponse::BadRequest().json(meta::http::HttpResponse::error(
-                http::StatusCode::BAD_REQUEST.into(),
-                "Bad Request".to_string(),
-            )),
-        )
+        Ok(HttpResponse::BadRequest().json(MetaHttpResponse::error(
+            http::StatusCode::BAD_REQUEST.into(),
+            "Bad Request".to_string(),
+        )))
     }
 }
 
@@ -103,12 +104,8 @@ pub async fn query(
     org_id: web::Path<String>,
     query: web::Query<meta::prom::RequestQuery>,
 ) -> Result<HttpResponse, Error> {
-    let org_id = org_id.into_inner();
     let query = query.into_inner();
-    println!("org_id: {}", org_id);
-    println!("query.query: {}", query.query);
-    println!("query.time: {:?}", query.time);
-    println!("query.timeout: {:?}", query.timeout);
+    tracing::trace!(%org_id, ?query);
     Ok(HttpResponse::NotImplemented().body("Not Implemented"))
 }
 
@@ -170,14 +167,8 @@ pub async fn query_range(
     org_id: web::Path<String>,
     range_query: web::Query<meta::prom::RequestRangeQuery>,
 ) -> Result<HttpResponse, Error> {
-    let org_id = org_id.into_inner();
     let range_query = range_query.into_inner();
-    println!("org_id: {}", org_id);
-    println!("query.query: {}", range_query.query);
-    println!("query.start: {:?}", range_query.start);
-    println!("query.end: {:?}", range_query.end);
-    println!("query.step: {:?}", range_query.step);
-    println!("query.timeout: {:?}", range_query.timeout);
+    tracing::trace!(%org_id, ?range_query);
     Ok(HttpResponse::NotImplemented().body("Not Implemented"))
 }
 
@@ -226,14 +217,17 @@ pub async fn query_range(
 #[get("/{org_id}/prometheus/v1/metadata")]
 pub async fn metadata(
     org_id: web::Path<String>,
-    metadata: web::Query<meta::prom::RequestMetadata>,
+    req: web::Query<meta::prom::RequestMetadata>,
 ) -> Result<HttpResponse, Error> {
-    let org_id = org_id.into_inner();
-    let metadata = metadata.into_inner();
-    println!("org_id: {}", org_id);
-    println!("query.limit: {}", metadata.limit);
-    println!("query.metric: {:?}", metadata.metric);
-    Ok(HttpResponse::NotImplemented().body("Not Implemented"))
+    let req = req.into_inner();
+    tracing::trace!(%org_id, ?req);
+    Ok(match metrics::prom::get_metadata(&org_id, req).await {
+        Ok(resp) => HttpResponse::Ok().json(resp),
+        Err(err) => HttpResponse::InternalServerError().json(MetaHttpResponse::error(
+            http::StatusCode::INTERNAL_SERVER_ERROR.into(),
+            err.to_string(),
+        )),
+    })
 }
 
 /** prometheus finding series by label matchers */
@@ -280,12 +274,8 @@ pub async fn series(
     org_id: web::Path<String>,
     series: web::Query<meta::prom::RequestSeries>,
 ) -> Result<HttpResponse, Error> {
-    let org_id = org_id.into_inner();
     let series = series.into_inner();
-    println!("org_id: {}", org_id);
-    println!("query.match[]: {:?}", series.matches);
-    println!("query.start: {:?}", series.start);
-    println!("query.end: {:?}", series.end);
+    tracing::trace!(%org_id, ?series);
     Ok(HttpResponse::NotImplemented().body("Not Implemented"))
 }
 
@@ -339,12 +329,8 @@ pub async fn labels(
     org_id: web::Path<String>,
     labels: web::Query<meta::prom::RequestLabels>,
 ) -> Result<HttpResponse, Error> {
-    let org_id = org_id.into_inner();
     let labels = labels.into_inner();
-    println!("org_id: {}", org_id);
-    println!("query.match[]: {:?}", labels.matches);
-    println!("query.start: {:?}", labels.start);
-    println!("query.end: {:?}", labels.end);
+    tracing::trace!(%org_id, ?labels);
     Ok(HttpResponse::NotImplemented().body("Not Implemented"))
 }
 
@@ -382,10 +368,6 @@ pub async fn values(
 ) -> Result<HttpResponse, Error> {
     let (org_id, label_name) = path.into_inner();
     let values = values.into_inner();
-    println!("org_id: {}", org_id);
-    println!("label_name: {}", label_name);
-    println!("query.match[]: {:?}", values.matches);
-    println!("query.start: {:?}", values.start);
-    println!("query.end: {:?}", values.end);
+    tracing::trace!(%org_id, %label_name, ?values);
     Ok(HttpResponse::NotImplemented().body("Not Implemented"))
 }

--- a/src/meta/mod.rs
+++ b/src/meta/mod.rs
@@ -32,15 +32,12 @@ pub mod traces;
 pub mod user;
 
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq, Serialize, Deserialize, ToSchema)]
+#[serde(rename_all = "lowercase")]
 pub enum StreamType {
     #[default]
-    #[serde(rename = "logs")]
     Logs,
-    #[serde(rename = "metrics")]
     Metrics,
-    #[serde(rename = "traces")]
     Traces,
-    #[serde(rename = "metadata")]
     Metadata,
     #[serde(rename = "file_list")]
     Filelist,

--- a/src/meta/prom.rs
+++ b/src/meta/prom.rs
@@ -13,6 +13,9 @@
 // limitations under the License.
 
 use serde::{Deserialize, Serialize};
+use strum::Display;
+
+use crate::service::metrics::prom::prometheus as proto;
 
 pub const NAME_LABEL: &str = "__name__";
 pub const TYPE_LABEL: &str = "__type__";
@@ -28,62 +31,51 @@ pub const METADATA_LABEL: &str = "prom_metadata";
 pub type FxIndexMap<K, V> =
     indexmap::IndexMap<K, V, std::hash::BuildHasherDefault<rustc_hash::FxHasher>>;
 
-#[derive(Clone, Debug, Serialize)]
+#[derive(Debug, Clone, Serialize)]
 pub struct Metric {
     #[serde(flatten)]
     pub labels: FxIndexMap<String, String>,
     pub value: f64,
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ClusterLeader {
     pub name: String,
     pub last_received: i64,
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize)]
+// cf. https://github.com/prometheus/prometheus/blob/f5fcaa3872ce03808567fabc56afc9cf61c732cb/model/textparse/interface.go#L106-L119
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, Display)]
+#[strum(serialize_all = "lowercase")]
 pub enum MetricType {
-    UNKNOWN,
-    COUNTER,
-    GAUGE,
-    HISTOGRAM,
-    GAUGEHISTOGRAM,
-    SUMMARY,
-    INFO,
-    STATESET,
+    Unknown,
+    Counter,
+    Gauge,
+    Histogram,
+    GaugeHistogram,
+    Summary,
+    Info,
+    StateSet,
 }
 
-impl From<&str> for MetricType {
-    fn from(s: &str) -> Self {
-        match s.to_uppercase().as_str() {
-            "COUNTER" => MetricType::COUNTER,
-            "GAUGE" => MetricType::GAUGE,
-            "HISTOGRAM" => MetricType::HISTOGRAM,
-            "GAUGEHISTOGRAM" => MetricType::GAUGEHISTOGRAM,
-            "SUMMARY" => MetricType::SUMMARY,
-            "INFO" => MetricType::INFO,
-            "STATESET" => MetricType::STATESET,
-            _ => MetricType::UNKNOWN,
+impl From<proto::metric_metadata::MetricType> for MetricType {
+    fn from(mt: proto::metric_metadata::MetricType) -> Self {
+        use proto::metric_metadata::MetricType as ProtoMetricType;
+
+        match mt {
+            ProtoMetricType::Unknown => Self::Unknown,
+            ProtoMetricType::Counter => Self::Counter,
+            ProtoMetricType::Gauge => Self::Gauge,
+            ProtoMetricType::Histogram => Self::Histogram,
+            ProtoMetricType::Gaugehistogram => Self::GaugeHistogram,
+            ProtoMetricType::Summary => Self::Summary,
+            ProtoMetricType::Info => Self::Info,
+            ProtoMetricType::Stateset => Self::StateSet,
         }
     }
 }
 
-impl MetricType {
-    pub fn as_str_name(&self) -> &'static str {
-        match self {
-            MetricType::UNKNOWN => "UNKNOWN",
-            MetricType::COUNTER => "COUNTER",
-            MetricType::GAUGE => "GAUGE",
-            MetricType::HISTOGRAM => "HISTOGRAM",
-            MetricType::GAUGEHISTOGRAM => "GAUGEHISTOGRAM",
-            MetricType::SUMMARY => "SUMMARY",
-            MetricType::INFO => "INFO",
-            MetricType::STATESET => "STATESET",
-        }
-    }
-}
-
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Metadata {
     pub metric_type: MetricType,
     pub metric_family_name: String,
@@ -135,4 +127,22 @@ pub struct RequestValues {
     pub matches: Option<Vec<String>>,
     pub start: Option<String>,
     pub end: Option<String>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_metric_type_display() {
+        assert_eq!(MetricType::Counter.to_string(), "counter");
+        assert_eq!(MetricType::Gauge.to_string(), "gauge");
+        assert_eq!(MetricType::Histogram.to_string(), "histogram");
+        assert_eq!(MetricType::GaugeHistogram.to_string(), "gaugehistogram");
+        assert_eq!(MetricType::Summary.to_string(), "summary");
+        assert_eq!(MetricType::Info.to_string(), "info");
+        assert_eq!(MetricType::StateSet.to_string(), "stateset");
+        assert_eq!(format!("{}", MetricType::Unknown), "unknown");
+        assert_eq!(MetricType::Unknown.to_string(), "unknown");
+    }
 }

--- a/src/meta/prom.rs
+++ b/src/meta/prom.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::collections::HashMap;
+
 use serde::{Deserialize, Serialize};
 use strum::Display;
 
@@ -83,6 +85,13 @@ pub struct Metadata {
     pub unit: String,
 }
 
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "lowercase")]
+pub enum Status {
+    Success,
+    Error,
+}
+
 #[derive(Debug, Deserialize)]
 pub struct RequestQuery {
     pub query: String,
@@ -101,8 +110,36 @@ pub struct RequestRangeQuery {
 
 #[derive(Debug, Deserialize)]
 pub struct RequestMetadata {
-    pub limit: i64,
+    /// Maximum number of metrics to return.
+    pub limit: Option<usize>,
+    /// A metric name to filter metadata for. All metric metadata is retrieved
+    /// if left empty.
     pub metric: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct ResponseMetadata {
+    pub status: Status,
+    /// key - metric name
+    pub data: HashMap<String, Vec<MetadataObject>>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct MetadataObject {
+    #[serde(rename = "type")]
+    typ: String, // counter, gauge, histogram, summary
+    help: String,
+    unit: String,
+}
+
+impl From<Metadata> for MetadataObject {
+    fn from(md: Metadata) -> Self {
+        Self {
+            typ: md.metric_type.to_string(),
+            help: md.help,
+            unit: md.unit,
+        }
+    }
 }
 
 #[derive(Debug, Deserialize)]

--- a/src/service/db/schema.rs
+++ b/src/service/db/schema.rs
@@ -27,6 +27,7 @@ fn mk_key(org_id: &str, stream_type: StreamType, stream_name: &str) -> String {
     format!("/schema/{org_id}/{stream_type}/{stream_name}")
 }
 
+// XXX-TODO: `get` never fails. Return `Schema` instead of `Result<Schema, _>`.
 pub async fn get(
     org_id: &str,
     stream_name: &str,
@@ -35,15 +36,8 @@ pub async fn get(
     let key = mk_key(org_id, stream_type.unwrap_or(StreamType::Logs), stream_name);
     let map_key = key.strip_prefix("/schema/").unwrap();
 
-    if STREAM_SCHEMAS.contains_key(map_key) {
-        return Ok(STREAM_SCHEMAS
-            .get(map_key)
-            .unwrap()
-            .value()
-            .clone()
-            .last()
-            .unwrap()
-            .clone());
+    if let Some(schema) = STREAM_SCHEMAS.get(map_key) {
+        return Ok(schema.value().clone().last().unwrap().clone());
     }
 
     let db = &crate::infra::db::DEFAULT;


### PR DESCRIPTION
Part of #692

### Other changes

Obtain `MetricType` directly from protobuf enum,
drop intermediate string representation.