### PR TITLE
fix: restart router when there is no nodes

### DIFF
--- a/src/service/router/mod.rs
+++ b/src/service/router/mod.rs
@@ -93,7 +93,7 @@ async fn dispatch(
     let mut nodes = nodes.unwrap();
     if nodes.is_empty() {
         log::error!("Not found online nodes, restaring...");
-        std::process::exit(0);
+        std::process::exit(1);
     }
 
     // random nodes


### PR DESCRIPTION
fix #720 

When router not found other nodes, just reload nodes from etcd maybe won't fix the problem. maybe the router disconnect from etcd. we need reconnect it and load everything again.

The better solution is, just let it `exit` and then `k8s` will restart it.