### PR TITLE
chore: validate metadata parameters

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -137,10 +137,7 @@ tokio = { version = "1", features = ["full"] }
 tonic = { version = "0.8", features = ["prost", "gzip"] }
 tracing = "0.1"
 tracing-opentelemetry = "0.18"
-tracing-subscriber = { version = "0.3", features = [
-  "tracing-log",
-  "env-filter",
-] }
+tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 url = "2.2"
 utoipa = { version = "3", features = ["actix_extras", "openapi_extensions"] }
 utoipa-swagger-ui = { version = "3", features = ["actix-web"] }

--- a/src/handler/http/request/prom/mod.rs
+++ b/src/handler/http/request/prom/mod.rs
@@ -360,7 +360,7 @@ pub async fn metadata(
     ),
     params(
         ("org_id" = String, Path, description = "Organization name"),
-        ("match[]" = Vec<String>, Query, description = "<series_selector>: Repeated series selector argument that selects the series to return. At least one match[] argument must be provided"),
+        ("match[]" = String, Query, description = "<series_selector>: Series selector argument that selects the series to return"),
         ("start" = Option<String>, Query, description = "<rfc3339 | unix_timestamp>: Start timestamp"),
         ("end" = Option<String>, Query, description = "<rfc3339 | unix_timestamp>: End timestamp"),
     ),
@@ -425,7 +425,7 @@ pub async fn series(
     ),
     params(
         ("org_id" = String, Path, description = "Organization name"),
-        ("match" = Option<Vec<String>>, Query, description = "Repeated series selector argument that selects the series from which to read the label names. Optional"),
+        ("match[]" = String, Query, description = "Series selector argument that selects the series from which to read the label names"),
         ("start" = Option<String>, Query, description = "<rfc3339 | unix_timestamp>: Start timestamp"),
         ("end" = Option<String>, Query, description = "<rfc3339 | unix_timestamp>: End timestamp"),
     ),
@@ -498,7 +498,7 @@ pub async fn labels(
     params(
         ("org_id" = String, Path, description = "Organization name"),
         ("label_name" = String, Path, description = "Label name"),
-        ("match" = Option<Vec<String>>, Query, description = "Repeated series selector argument that selects the series from which to read the label names. Optional"),
+        ("match[]" = String, Query, description = "Series selector argument that selects the series from which to read the label values"),
         ("start" = Option<String>, Query, description = "<rfc3339 | unix_timestamp>: Start timestamp"),
         ("end" = Option<String>, Query, description = "<rfc3339 | unix_timestamp>: End timestamp"),
     ),

--- a/src/handler/http/request/prom/mod.rs
+++ b/src/handler/http/request/prom/mod.rs
@@ -12,14 +12,17 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use actix_web::{get, http, post, web, HttpRequest, HttpResponse};
 use std::io::Error;
 
-use crate::common::time::{parse_milliseconds, parse_str_to_timestamp_micros};
-use crate::infra::errors;
-use crate::meta::{self, http::HttpResponse as MetaHttpResponse};
-use crate::service::metrics;
-use crate::service::promql;
+use actix_web::{get, http, post, web, HttpRequest, HttpResponse};
+use promql_parser::parser;
+
+use crate::{
+    common::time::{parse_milliseconds, parse_str_to_timestamp_micros},
+    infra::errors,
+    meta::{self, http::HttpResponse as MetaHttpResponse},
+    service::{metrics, promql},
+};
 
 /** prometheus remote-write endpoint for metrics */
 #[utoipa::path(
@@ -128,7 +131,7 @@ pub async fn query(
         is_range_query: false,
         start,
         end,
-        step: 300_000_000,
+        step: 300_000_000, // 5m
     };
 
     match promql::search::search(&org_id, &req).await {
@@ -240,7 +243,7 @@ pub async fn query_range(
         }
     };
     let step = match range_query.step {
-        None => 300_000_000,
+        None => 300_000_000, // 5m
         Some(v) => match parse_milliseconds(&v) {
             Ok(v) => (v * 1_000) as i64,
             Err(e) => {
@@ -262,7 +265,6 @@ pub async fn query_range(
         end,
         step,
     };
-
     match promql::search::search(&org_id, &req).await {
         Ok(data) => Ok(HttpResponse::Ok().json(promql::QueryResponse {
             status: promql::Status::Success,
@@ -335,15 +337,16 @@ pub async fn metadata(
     org_id: web::Path<String>,
     req: web::Query<meta::prom::RequestMetadata>,
 ) -> Result<HttpResponse, Error> {
-    let req = req.into_inner();
-    tracing::trace!(%org_id, ?req);
-    Ok(match metrics::prom::get_metadata(&org_id, req).await {
-        Ok(resp) => HttpResponse::Ok().json(resp),
-        Err(err) => HttpResponse::InternalServerError().json(MetaHttpResponse::error(
-            http::StatusCode::INTERNAL_SERVER_ERROR.into(),
-            err.to_string(),
-        )),
-    })
+    Ok(metrics::prom::get_metadata(&org_id, req.into_inner())
+        .await
+        .map_or_else(
+            |e| {
+                log::error!("get_metadata failed: {e}");
+                promql::ApiFuncResponse::err_internal(e)
+            },
+            promql::ApiFuncResponse::ok,
+        )
+        .into())
 }
 
 /** prometheus finding series by label matchers */
@@ -357,7 +360,7 @@ pub async fn metadata(
     ),
     params(
         ("org_id" = String, Path, description = "Organization name"),
-        ("match" = Vec<String>, Query, description = "<series_selector>: Repeated series selector argument that selects the series to return. At least one match[] argument must be provided"),
+        ("match[]" = Vec<String>, Query, description = "<series_selector>: Repeated series selector argument that selects the series to return. At least one match[] argument must be provided"),
         ("start" = Option<String>, Query, description = "<rfc3339 | unix_timestamp>: Start timestamp"),
         ("end" = Option<String>, Query, description = "<rfc3339 | unix_timestamp>: End timestamp"),
     ),
@@ -388,11 +391,27 @@ pub async fn metadata(
 #[get("/{org_id}/prometheus/api/v1/series")]
 pub async fn series(
     org_id: web::Path<String>,
-    series: web::Query<meta::prom::RequestSeries>,
+    req: web::Query<meta::prom::RequestSeries>,
 ) -> Result<HttpResponse, Error> {
-    let series = series.into_inner();
-    tracing::trace!(%org_id, ?series);
-    Ok(HttpResponse::NotImplemented().body("Not Implemented"))
+    let meta::prom::RequestSeries {
+        matcher,
+        start,
+        end,
+    } = req.into_inner();
+    let (selector, start, end) = match validate_metadata_params(matcher, start, end) {
+        Ok(v) => v,
+        Err(e) => return Ok(promql::ApiFuncResponse::<()>::err_bad_data(e).into()),
+    };
+    Ok(metrics::prom::get_series(&org_id, selector, start, end)
+        .await
+        .map_or_else(
+            |e| {
+                log::error!("get_series failed: {e}");
+                promql::ApiFuncResponse::err_internal(e)
+            },
+            promql::ApiFuncResponse::ok,
+        )
+        .into())
 }
 
 /** prometheus getting label names */
@@ -443,11 +462,28 @@ pub async fn series(
 #[get("/{org_id}/prometheus/api/v1/labels")]
 pub async fn labels(
     org_id: web::Path<String>,
-    labels: web::Query<meta::prom::RequestLabels>,
+    req: web::Query<meta::prom::RequestLabels>,
 ) -> Result<HttpResponse, Error> {
-    let labels = labels.into_inner();
-    tracing::trace!(%org_id, ?labels);
-    Ok(HttpResponse::NotImplemented().body("Not Implemented"))
+    let meta::prom::RequestLabels {
+        matcher,
+        start,
+        end,
+    } = req.into_inner();
+    let (selector, start, end) = match validate_metadata_params(matcher, start, end) {
+        Ok(v) => v,
+        Err(e) => return Ok(promql::ApiFuncResponse::<()>::err_bad_data(e).into()),
+    };
+
+    Ok(metrics::prom::get_labels(&org_id, selector, start, end)
+        .await
+        .map_or_else(
+            |e| {
+                log::error!("get_labels failed: {e}");
+                promql::ApiFuncResponse::err_internal(e)
+            },
+            promql::ApiFuncResponse::ok,
+        )
+        .into())
 }
 
 /** prometheus query label values */
@@ -478,12 +514,88 @@ pub async fn labels(
     )
 )]
 #[get("/{org_id}/prometheus/api/v1/label/{label_name}/values")]
-pub async fn values(
+pub async fn label_values(
     path: web::Path<(String, String)>,
-    values: web::Query<meta::prom::RequestValues>,
+    req: web::Query<meta::prom::RequestLabelValues>,
 ) -> Result<HttpResponse, Error> {
     let (org_id, label_name) = path.into_inner();
-    let values = values.into_inner();
-    tracing::trace!(%org_id, %label_name, ?values);
-    Ok(HttpResponse::NotImplemented().body("Not Implemented"))
+    let meta::prom::RequestLabelValues {
+        matcher,
+        start,
+        end,
+    } = req.into_inner();
+    let (selector, start, end) = match validate_metadata_params(matcher, start, end) {
+        Ok(v) => v,
+        Err(e) => return Ok(promql::ApiFuncResponse::<()>::err_bad_data(e).into()),
+    };
+    Ok(
+        metrics::prom::get_label_values(&org_id, label_name, selector, start, end)
+            .await
+            .map_or_else(
+                |e| {
+                    log::error!("get_label_values failed: {e}");
+                    promql::ApiFuncResponse::err_internal(e)
+                },
+                promql::ApiFuncResponse::ok,
+            )
+            .into(),
+    )
+}
+
+fn validate_metadata_params(
+    matcher: String,
+    start: Option<String>,
+    end: Option<String>,
+) -> Result<(parser::VectorSelector, i64, i64), String> {
+    let selector = match parser::parse(&matcher) {
+        Err(err) => {
+            let err = format!("parse promql error: {err}");
+            log::error!("{err}");
+            return Err(err);
+        }
+        Ok(parser::Expr::VectorSelector(sel)) => {
+            let err = if sel.name.is_none() {
+                Some("match[] argument must start with a metric name, e.g. `match[]=up`")
+            } else if sel.offset.is_some() {
+                Some("match[]: unexpected offset modifier")
+            } else if sel.at.is_some() {
+                Some("match[]: unexpected @ modifier")
+            } else {
+                None
+            };
+            if let Some(err) = err {
+                log::error!("{err}");
+                return Err(err.to_owned());
+            }
+            sel
+        }
+        Ok(_expr) => {
+            let err = "vector selector expected";
+            log::error!("{err}");
+            return Err(err.to_owned());
+        }
+    };
+    let start = match start {
+        None => 0,
+        Some(s) => match parse_str_to_timestamp_micros(&s) {
+            Ok(t) => t,
+            Err(e) => {
+                let err = format!("parse time error: {e}");
+                log::error!("{err}");
+                return Err(err);
+            }
+        },
+    };
+    let end = match end {
+        None => i64::MAX,
+        Some(s) => match parse_str_to_timestamp_micros(&s) {
+            Ok(t) => t,
+            Err(e) => {
+                let err = format!("parse time error: {e}");
+                log::error!("{err}");
+                return Err(err);
+            }
+        },
+    };
+    Ok((selector, start, end))
 }

--- a/src/handler/http/request/prom/mod.rs
+++ b/src/handler/http/request/prom/mod.rs
@@ -337,16 +337,16 @@ pub async fn metadata(
     org_id: web::Path<String>,
     req: web::Query<meta::prom::RequestMetadata>,
 ) -> Result<HttpResponse, Error> {
-    Ok(metrics::prom::get_metadata(&org_id, req.into_inner())
-        .await
-        .map_or_else(
-            |e| {
-                log::error!("get_metadata failed: {e}");
-                promql::ApiFuncResponse::err_internal(e)
-            },
-            promql::ApiFuncResponse::ok,
-        )
-        .into())
+    Ok(
+        match metrics::prom::get_metadata(&org_id, req.into_inner()).await {
+            Ok(resp) => HttpResponse::Ok().json(promql::ApiFuncResponse::ok(resp)),
+            Err(err) => {
+                log::error!("get_metadata failed: {err}");
+                HttpResponse::InternalServerError()
+                    .json(promql::ApiFuncResponse::<()>::err_internal(err.to_string()))
+            }
+        },
+    )
 }
 
 /** prometheus finding series by label matchers */
@@ -400,18 +400,22 @@ pub async fn series(
     } = req.into_inner();
     let (selector, start, end) = match validate_metadata_params(matcher, start, end) {
         Ok(v) => v,
-        Err(e) => return Ok(promql::ApiFuncResponse::<()>::err_bad_data(e).into()),
+        Err(e) => {
+            return Ok(
+                HttpResponse::BadRequest().json(promql::ApiFuncResponse::<()>::err_bad_data(e))
+            )
+        }
     };
-    Ok(metrics::prom::get_series(&org_id, selector, start, end)
-        .await
-        .map_or_else(
-            |e| {
-                log::error!("get_series failed: {e}");
-                promql::ApiFuncResponse::err_internal(e)
-            },
-            promql::ApiFuncResponse::ok,
-        )
-        .into())
+    Ok(
+        match metrics::prom::get_series(&org_id, selector, start, end).await {
+            Ok(resp) => HttpResponse::Ok().json(promql::ApiFuncResponse::ok(resp)),
+            Err(err) => {
+                log::error!("get_series failed: {err}");
+                HttpResponse::InternalServerError()
+                    .json(promql::ApiFuncResponse::<()>::err_internal(err.to_string()))
+            }
+        },
+    )
 }
 
 /** prometheus getting label names */
@@ -471,19 +475,22 @@ pub async fn labels(
     } = req.into_inner();
     let (selector, start, end) = match validate_metadata_params(matcher, start, end) {
         Ok(v) => v,
-        Err(e) => return Ok(promql::ApiFuncResponse::<()>::err_bad_data(e).into()),
+        Err(e) => {
+            return Ok(
+                HttpResponse::BadRequest().json(promql::ApiFuncResponse::<()>::err_bad_data(e))
+            )
+        }
     };
-
-    Ok(metrics::prom::get_labels(&org_id, selector, start, end)
-        .await
-        .map_or_else(
-            |e| {
-                log::error!("get_labels failed: {e}");
-                promql::ApiFuncResponse::err_internal(e)
-            },
-            promql::ApiFuncResponse::ok,
-        )
-        .into())
+    Ok(
+        match metrics::prom::get_labels(&org_id, selector, start, end).await {
+            Ok(resp) => HttpResponse::Ok().json(promql::ApiFuncResponse::ok(resp)),
+            Err(err) => {
+                log::error!("get_labels failed: {err}");
+                HttpResponse::InternalServerError()
+                    .json(promql::ApiFuncResponse::<()>::err_internal(err.to_string()))
+            }
+        },
+    )
 }
 
 /** prometheus query label values */
@@ -526,19 +533,21 @@ pub async fn label_values(
     } = req.into_inner();
     let (selector, start, end) = match validate_metadata_params(matcher, start, end) {
         Ok(v) => v,
-        Err(e) => return Ok(promql::ApiFuncResponse::<()>::err_bad_data(e).into()),
+        Err(e) => {
+            return Ok(
+                HttpResponse::BadRequest().json(promql::ApiFuncResponse::<()>::err_bad_data(e))
+            )
+        }
     };
     Ok(
-        metrics::prom::get_label_values(&org_id, label_name, selector, start, end)
-            .await
-            .map_or_else(
-                |e| {
-                    log::error!("get_label_values failed: {e}");
-                    promql::ApiFuncResponse::err_internal(e)
-                },
-                promql::ApiFuncResponse::ok,
-            )
-            .into(),
+        match metrics::prom::get_label_values(&org_id, label_name, selector, start, end).await {
+            Ok(resp) => HttpResponse::Ok().json(promql::ApiFuncResponse::ok(resp)),
+            Err(err) => {
+                log::error!("get_label_values failed: {err}");
+                HttpResponse::InternalServerError()
+                    .json(promql::ApiFuncResponse::<()>::err_internal(err.to_string()))
+            }
+        },
     )
 }
 

--- a/src/handler/http/router/mod.rs
+++ b/src/handler/http/router/mod.rs
@@ -146,7 +146,7 @@ pub fn get_service_routes(cfg: &mut web::ServiceConfig) {
             .service(prom::metadata)
             .service(prom::series)
             .service(prom::labels)
-            .service(prom::values)
+            .service(prom::label_values)
             .service(create_dashboard)
             .service(update_dashboard)
             .service(list_dashboards)

--- a/src/handler/http/router/openapi.rs
+++ b/src/handler/http/router/openapi.rs
@@ -78,7 +78,7 @@ use crate::meta;
         request::prom::metadata,
         request::prom::series,
         request::prom::labels,
-        request::prom::values,
+        request::prom::label_values,
         request::traces::traces_write,
     ),
     components(

--- a/src/meta/prom.rs
+++ b/src/meta/prom.rs
@@ -158,7 +158,7 @@ pub struct RequestSeries {
     /// Series selector argument that selects the series to return.
     ///
     /// NOTE: Prometheus API allows passing multiple `match[]` arguments,
-    /// but ZincObserver only supports a single one.
+    /// but ZincObserve only supports a single one.
     #[serde(rename = "match[]")]
     pub matcher: String,
     /// Start timestamp.
@@ -179,7 +179,7 @@ pub struct RequestLabels {
     /// the label names.
     ///
     /// NOTE: Prometheus API allows passing any number of `match[]` arguments,
-    /// but ZincObserver requires that exactly one is passed.
+    /// but ZincObserve requires that exactly one is passed.
     #[serde(rename = "match[]")]
     pub matcher: String,
     /// Start timestamp.
@@ -200,7 +200,7 @@ pub struct RequestLabelValues {
     /// the label values.
     ///
     /// NOTE: Prometheus API allows passing any number of `match[]` arguments,
-    /// but ZincObserver requires that exactly one is passed.
+    /// but ZincObserve requires that exactly one is passed.
     #[serde(rename = "match[]")]
     pub matcher: String,
     /// Start timestamp.

--- a/src/meta/prom.rs
+++ b/src/meta/prom.rs
@@ -92,19 +92,29 @@ pub enum Status {
     Error,
 }
 
+/// Instant query.
 #[derive(Debug, Deserialize)]
 pub struct RequestQuery {
+    /// PromQL expression.
     pub query: String,
+    /// Evaluation timestamp. Defaults to current server time.
     pub time: Option<String>,
+    /// Evaluation timeout.
     pub timeout: Option<String>,
 }
 
+/// Range query.
 #[derive(Debug, Deserialize)]
 pub struct RequestRangeQuery {
+    /// PromQL expression.
     pub query: String,
+    /// Start timestamp, inclusive.
     pub start: String,
+    /// End timestamp, inclusive.
     pub end: String,
+    /// Query resolution step width in `duration` format or float number of seconds.
     pub step: Option<String>,
+    /// Evaluation timeout.
     pub timeout: Option<String>,
 }
 
@@ -142,28 +152,66 @@ impl From<Metadata> for MetadataObject {
     }
 }
 
+/// Request a list of time series that match a certain label set.
 #[derive(Debug, Deserialize)]
 pub struct RequestSeries {
-    #[serde(rename = "match")]
-    pub matches: Vec<String>,
+    /// Series selector argument that selects the series to return.
+    ///
+    /// NOTE: Prometheus API allows passing multiple `match[]` arguments,
+    /// but ZincObserver only supports a single one.
+    #[serde(rename = "match[]")]
+    pub matcher: String,
+    /// Start timestamp.
     pub start: Option<String>,
+    /// End timestamp.
     pub end: Option<String>,
 }
 
+#[derive(Debug, Serialize)]
+pub struct ResponseSeries {
+    // XXX-TODO: IMPLEMENTME
+}
+
+/// Request a list of label names.
 #[derive(Debug, Deserialize)]
 pub struct RequestLabels {
-    #[serde(rename = "match")]
-    pub matches: Option<Vec<String>>,
+    /// Series selector argument that selects the series from which to read
+    /// the label names.
+    ///
+    /// NOTE: Prometheus API allows passing any number of `match[]` arguments,
+    /// but ZincObserver requires that exactly one is passed.
+    #[serde(rename = "match[]")]
+    pub matcher: String,
+    /// Start timestamp.
     pub start: Option<String>,
+    /// End timestamp.
     pub end: Option<String>,
 }
 
+#[derive(Debug, Serialize)]
+pub(crate) struct ResponseLabels {
+    // XXX-TODO: IMPLEMENTME
+}
+
+/// Request a list of label values for a provided label name.
 #[derive(Debug, Deserialize)]
-pub struct RequestValues {
-    #[serde(rename = "match")]
-    pub matches: Option<Vec<String>>,
+pub struct RequestLabelValues {
+    /// Series selector argument that selects the series from which to read
+    /// the label values.
+    ///
+    /// NOTE: Prometheus API allows passing any number of `match[]` arguments,
+    /// but ZincObserver requires that exactly one is passed.
+    #[serde(rename = "match[]")]
+    pub matcher: String,
+    /// Start timestamp.
     pub start: Option<String>,
+    /// End timestamp.
     pub end: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+pub(crate) struct ResponseLabelValues {
+    // XXX-TODO: IMPLEMENTME
 }
 
 #[cfg(test)]

--- a/src/service/promql/mod.rs
+++ b/src/service/promql/mod.rs
@@ -57,3 +57,96 @@ pub struct QueryResponse {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub error: Option<String>,
 }
+
+#[derive(Debug, Serialize)]
+#[serde(tag = "status", rename_all = "lowercase")]
+pub(crate) enum ApiFuncResponse<T: Serialize> {
+    Success {
+        data: T,
+    },
+    Error {
+        #[serde(rename = "errorType")]
+        error_type: ApiErrorType,
+        error: String,
+    },
+}
+
+impl<T: Serialize> From<ApiFuncResponse<T>> for actix_web::HttpResponse {
+    fn from(resp: ApiFuncResponse<T>) -> Self {
+        match resp {
+            ok @ ApiFuncResponse::Success { .. } => actix_web::HttpResponse::Ok().json(ok),
+            err @ ApiFuncResponse::Error {
+                error_type: ApiErrorType::BadData,
+                ..
+            } => actix_web::HttpResponse::BadRequest().json(err),
+            err @ ApiFuncResponse::Error { .. } => {
+                actix_web::HttpResponse::InternalServerError().json(err)
+            }
+        }
+    }
+}
+
+impl<T: Serialize> ApiFuncResponse<T> {
+    pub(crate) fn ok(data: T) -> Self {
+        ApiFuncResponse::Success { data }
+    }
+
+    pub(crate) fn err_bad_data(error: impl ToString) -> Self {
+        ApiFuncResponse::Error {
+            error_type: ApiErrorType::BadData,
+            error: error.to_string(),
+        }
+    }
+
+    pub(crate) fn err_internal(error: impl ToString) -> Self {
+        ApiFuncResponse::Error {
+            error_type: ApiErrorType::Internal,
+            error: error.to_string(),
+        }
+    }
+}
+
+// cf. https://github.com/prometheus/prometheus/blob/5c5fa5c319fca713506fa144ec6768fddf00d466/web/api/v1/api.go#L73-L82
+#[derive(Debug, Clone, Copy, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ApiErrorType {
+    Timeout,
+    Cancelled,
+    Exec,
+    BadData,
+    Internal,
+    Unavailable,
+    NotFound,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use expect_test::expect;
+
+    #[test]
+    fn test_api_func_response_serialize() {
+        let ok = ApiFuncResponse::ok("hello".to_owned());
+        assert_eq!(
+            serde_json::to_string(&ok).unwrap(),
+            r#"{"status":"success","data":"hello"}"#
+        );
+
+        let err = ApiFuncResponse::<()>::err_internal("something went wrong".to_owned());
+        assert_eq!(
+            serde_json::to_string(&err).unwrap(),
+            r#"{"status":"error","errorType":"internal","error":"something went wrong"}"#
+        );
+
+        let err = ApiFuncResponse::<()>::err_bad_data(
+            r#"invalid parameter \"start\": Invalid time value for 'start': cannot parse \"foobar\" to a valid timestamp"#,
+        );
+        expect![[r#"
+            {
+              "status": "error",
+              "errorType": "bad_data",
+              "error": "invalid parameter \\\"start\\\": Invalid time value for 'start': cannot parse \\\"foobar\\\" to a valid timestamp"
+            }"#
+        ]].assert_eq(&serde_json::to_string_pretty(&err).unwrap());
+    }
+}

--- a/src/service/promql/mod.rs
+++ b/src/service/promql/mod.rs
@@ -71,21 +71,6 @@ pub(crate) enum ApiFuncResponse<T: Serialize> {
     },
 }
 
-impl<T: Serialize> From<ApiFuncResponse<T>> for actix_web::HttpResponse {
-    fn from(resp: ApiFuncResponse<T>) -> Self {
-        match resp {
-            ok @ ApiFuncResponse::Success { .. } => actix_web::HttpResponse::Ok().json(ok),
-            err @ ApiFuncResponse::Error {
-                error_type: ApiErrorType::BadData,
-                ..
-            } => actix_web::HttpResponse::BadRequest().json(err),
-            err @ ApiFuncResponse::Error { .. } => {
-                actix_web::HttpResponse::InternalServerError().json(err)
-            }
-        }
-    }
-}
-
 impl<T: Serialize> ApiFuncResponse<T> {
     pub(crate) fn ok(data: T) -> Self {
         ApiFuncResponse::Success { data }

--- a/src/service/promql/search/mod.rs
+++ b/src/service/promql/search/mod.rs
@@ -25,11 +25,11 @@ use crate::infra::cluster::{self, get_internal_grpc_token};
 use crate::infra::config::CONFIG;
 use crate::infra::db::etcd;
 use crate::infra::errors::{Error, ErrorCodes, Result};
-use crate::service::promql::value::*;
+use crate::service::promql::{self, value::*};
 
 pub mod grpc;
 
-pub async fn search(org_id: &str, req: &super::MetricsQueryRequest) -> Result<Value> {
+pub async fn search(org_id: &str, req: &promql::MetricsQueryRequest) -> Result<Value> {
     let root_span = info_span!("service:promql:search:enter");
     let mut req: cluster_rpc::MetricsQueryRequest = req.to_owned().into();
     req.org_id = org_id.to_string();


### PR DESCRIPTION
Part of #692.

HACK: require exactly one `match[]` argument.

NOTE: correct name is `Matchers`, not _matches_; see
- [`promql_parser::label::Matchers`](https://docs.rs/promql-parser/latest/promql_parser/label/struct.Matchers.html)
- [`LabelMatcher`](https://github.com/zinclabs/zincobserve/blob/3843631adedbbef8a0fd199c2778c2c06ec17c39/proto/prometheus/types.proto#L141-L152) in Prometheus' protobuf