### PR TITLE
fix: default Y-axis aggs function should be count

### DIFF
--- a/src/meta/dashboards.rs
+++ b/src/meta/dashboards.rs
@@ -98,13 +98,13 @@ pub struct AxisItem {
 #[serde(rename_all = "lowercase")]
 pub enum AggregationFunc {
     Count,
+    #[serde(rename = "count-distinct")]
+    CountDistinct,
     Histogram,
     Sum,
     Min,
     Max,
     Avg,
-    #[serde(rename = "count-distinct")]
-    CountDistinct,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, ToSchema)]

--- a/web/src/components/dashboards/addPanel/Layout.vue
+++ b/web/src/components/dashboards/addPanel/Layout.vue
@@ -372,11 +372,11 @@ export default defineComponent({
     } = useDashboardPanelData();
     const triggerOperators = [
       {label: "Count", value: "count"},
+      {label: "Count (Distinct)", value: "count-distinct"},
       {label: "Sum", value: "sum"},
       {label: "Avg", value: "avg"},
       {label: "Min", value: "min"},
       {label: "Max", value: "max"},
-      {label: "Count (Distinct)", value: "count-distinct"},
     ]
     const triggerOperatorsWithHistogram: any = [ {label: "Histogram", value: "histogram"} ]
 

--- a/web/src/composables/useDashboardPanel.ts
+++ b/web/src/composables/useDashboardPanel.ts
@@ -160,7 +160,7 @@ const useDashboardPanelData = () => {
         alias: !dashboardPanelData.data.customQuery ? 'y_axis_' + (dashboardPanelData.data.fields.y.length + 1) : row.name,
         column: row.name,
         color: getNewColorValue(),
-        aggregationFunction: row.type == 'Utf8' ? 'count-distinct' : row.type == 'Int64' ? 'sum' : 'count'
+        aggregationFunction: 'count'
       })
     }
     updateArrayAlias()


### PR DESCRIPTION
set default `count-distinct` for y-axis(string), `sum` for y-axis(int) is not suitable, because user add y-axis most cases for show the number. and we have no way to `count(*)`, user must select one field, most user select `log` or `message` for y-axis, so what happened?

```sql
select count(distinct(log)) as y-axis-1
```

or I select `_timestamp` for y-axis, just want to should how many by histogram, then the SQL is:

```sql
select sum(_timestamp) as y-axis-1
```

So, the better solution should keep y-axis aggregation function default is `count`.