### PR TITLE
chore: rerun the build script if any of protobufs change

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -17,6 +17,9 @@ use std::io::Result;
 use std::process::Command;
 
 fn main() -> Result<()> {
+    println!("cargo:rerun-if-changed=build.rs");
+    println!("cargo:rerun-if-changed=proto");
+
     tonic_build::configure()
         .type_attribute("FileList", "#[derive(Eq)]")
         .type_attribute("FileList", "#[derive(serde::Serialize)]")


### PR DESCRIPTION
These print statements tell Cargo that it needs to rerun the build script if either `build.rs` was modified or any of the files in `proto/` directory was changed.

Without these print statements Cargo doesn't notice edits of *.proto files.

### Before

1. Developer executes cargo check/clippy/run/build
2. Developer edits a *.proto file
3. Developer tries to check/clippy/run/build again
4. No recompilation happens — *bad*

### After

1–3. ...same...
4. Code is recompiled — *good*