### PR TITLE
fix: don't extrapolate when evaluating vector selector

### DIFF
--- a/proto/cluster/metrics.proto
+++ b/proto/cluster/metrics.proto
@@ -37,10 +37,10 @@ message MetricsQueryResponse {
 }
 
 message Series {
-    repeated Label  metric = 1;
-    repeated Sample values = 2;
-    optional Sample  value = 3;
-    optional double scalar = 4;
+    repeated Label   metric = 1;
+    repeated Sample samples = 2;
+    optional Sample  sample = 3;
+    optional double  scalar = 4;
 }
 
 message Label {

--- a/src/service/promql/aggregations/avg.rs
+++ b/src/service/promql/aggregations/avg.rs
@@ -27,7 +27,7 @@ pub fn avg(timestamp: i64, param: &Option<LabelModifier>, data: &Value) -> Resul
         .values()
         .map(|v| InstantValue {
             labels: v.labels.clone(),
-            value: Sample {
+            sample: Sample {
                 timestamp,
                 value: v.value / v.num as f64,
             },

--- a/src/service/promql/aggregations/count.rs
+++ b/src/service/promql/aggregations/count.rs
@@ -27,7 +27,7 @@ pub fn count(timestamp: i64, param: &Option<LabelModifier>, data: &Value) -> Res
         .values()
         .map(|v| InstantValue {
             labels: v.labels.clone(),
-            value: Sample {
+            sample: Sample {
                 timestamp,
                 value: v.num as f64,
             },

--- a/src/service/promql/aggregations/max.rs
+++ b/src/service/promql/aggregations/max.rs
@@ -39,7 +39,7 @@ pub fn max(timestamp: i64, param: &Option<LabelModifier>, data: &Value) -> Resul
         .values()
         .map(|v| InstantValue {
             labels: v.labels.clone(),
-            value: Sample {
+            sample: Sample {
                 timestamp,
                 value: v.value,
             },

--- a/src/service/promql/aggregations/min.rs
+++ b/src/service/promql/aggregations/min.rs
@@ -33,7 +33,7 @@ pub fn min(timestamp: i64, param: &Option<LabelModifier>, data: &Value) -> Resul
         .values()
         .map(|v| InstantValue {
             labels: v.labels.clone(),
-            value: Sample {
+            sample: Sample {
                 timestamp,
                 value: v.value,
             },

--- a/src/service/promql/aggregations/mod.rs
+++ b/src/service/promql/aggregations/mod.rs
@@ -81,7 +81,7 @@ pub(crate) fn eval_arithmetic(
                         value: 0.0,
                         num: 0,
                     });
-                    entry.value = f_handler(entry.value, item.value.value);
+                    entry.value = f_handler(entry.value, item.sample.value);
                     entry.num += 1;
                 }
             }
@@ -99,7 +99,7 @@ pub(crate) fn eval_arithmetic(
                         value: 0.0,
                         num: 0,
                     });
-                    entry.value = f_handler(entry.value, item.value.value);
+                    entry.value = f_handler(entry.value, item.sample.value);
                     entry.num += 1;
                 }
             }
@@ -113,7 +113,7 @@ pub(crate) fn eval_arithmetic(
                         value: 0.0,
                         num: 0,
                     });
-                entry.value = f_handler(entry.value, item.value.value);
+                entry.value = f_handler(entry.value, item.sample.value);
                 entry.num += 1;
             }
         }
@@ -151,12 +151,12 @@ pub async fn eval_top(
 
     let mut score_values = Vec::new();
     for (i, item) in data.iter().enumerate() {
-        if item.value.value.is_nan() {
+        if item.sample.value.is_nan() {
             continue;
         }
         score_values.push(TopItem {
             index: i,
-            value: item.value.value,
+            value: item.sample.value,
         });
     }
 

--- a/src/service/promql/aggregations/sum.rs
+++ b/src/service/promql/aggregations/sum.rs
@@ -27,7 +27,7 @@ pub fn sum(timestamp: i64, param: &Option<LabelModifier>, data: &Value) -> Resul
         .values()
         .map(|v| InstantValue {
             labels: v.labels.clone(),
-            value: Sample {
+            sample: Sample {
                 timestamp,
                 value: v.value,
             },

--- a/src/service/promql/functions/avg_over_time.rs
+++ b/src/service/promql/functions/avg_over_time.rs
@@ -21,8 +21,8 @@ pub(crate) fn avg_over_time(data: &Value) -> Result<Value> {
 }
 
 fn exec(data: &RangeValue) -> Option<f64> {
-    if data.values.is_empty() {
+    if data.samples.is_empty() {
         return None;
     }
-    Some(data.values.iter().map(|s| s.value).sum::<f64>() / data.values.len() as f64)
+    Some(data.samples.iter().map(|s| s.value).sum::<f64>() / data.samples.len() as f64)
 }

--- a/src/service/promql/functions/count_over_time.rs
+++ b/src/service/promql/functions/count_over_time.rs
@@ -21,8 +21,8 @@ pub(crate) fn count_over_time(data: &Value) -> Result<Value> {
 }
 
 fn exec(data: &RangeValue) -> Option<f64> {
-    if data.values.is_empty() {
+    if data.samples.is_empty() {
         return None;
     }
-    Some(data.values.len() as f64)
+    Some(data.samples.len() as f64)
 }

--- a/src/service/promql/functions/histogram.rs
+++ b/src/service/promql/functions/histogram.rs
@@ -51,11 +51,7 @@ pub(crate) fn histogram_quantile(sample_time: i64, phi: f64, data: Value) -> Res
     };
 
     let mut metrics_with_buckets: FxHashMap<Signature, MetricWithBuckets> = FxHashMap::default();
-    for InstantValue {
-        mut labels,
-        value: sample,
-    } in in_vec
-    {
+    for InstantValue { mut labels, sample } in in_vec {
         // [https://prometheus.io/docs/prometheus/latest/querying/functions/#histogram_quantile]:
         //
         // The conventional float samples in `in_vec` are considered the counts
@@ -90,7 +86,7 @@ pub(crate) fn histogram_quantile(sample_time: i64, phi: f64, data: Value) -> Res
         .into_values()
         .map(|mb| InstantValue {
             labels: mb.labels,
-            value: Sample {
+            sample: Sample {
                 timestamp: sample_time,
                 value: bucket_quantile(phi, mb.buckets),
             },

--- a/src/service/promql/functions/idelta.rs
+++ b/src/service/promql/functions/idelta.rs
@@ -21,12 +21,12 @@ pub(crate) fn idelta(data: &Value) -> Result<Value> {
 }
 
 fn exec(data: &RangeValue) -> Option<f64> {
-    if data.values.is_empty() {
+    if data.samples.is_empty() {
         return None;
-    } else if data.values.len() == 1 {
+    } else if data.samples.len() == 1 {
         return Some(0.0);
     }
-    let (last, data) = data.values.split_last().unwrap();
+    let (last, data) = data.samples.split_last().unwrap();
     let previous = data.last().unwrap();
     Some(last.value - previous.value)
 }

--- a/src/service/promql/functions/irate.rs
+++ b/src/service/promql/functions/irate.rs
@@ -21,12 +21,12 @@ pub(crate) fn irate(data: &Value) -> Result<Value> {
 }
 
 fn exec(data: &RangeValue) -> Option<f64> {
-    if data.values.is_empty() {
+    if data.samples.is_empty() {
         return None;
-    } else if data.values.len() == 1 {
+    } else if data.samples.len() == 1 {
         return Some(0.0);
     }
-    let (last, data) = data.values.split_last().unwrap();
+    let (last, data) = data.samples.split_last().unwrap();
     let previous = data.last().unwrap();
     let dt_seconds = ((last.timestamp - previous.timestamp) / 1_000_000) as f64;
     if dt_seconds == 0.0 {

--- a/src/service/promql/functions/max_over_time.rs
+++ b/src/service/promql/functions/max_over_time.rs
@@ -21,11 +21,11 @@ pub(crate) fn max_over_time(data: &Value) -> Result<Value> {
 }
 
 fn exec(data: &RangeValue) -> Option<f64> {
-    if data.values.is_empty() {
+    if data.samples.is_empty() {
         return None;
     }
     Some(
-        data.values
+        data.samples
             .iter()
             .map(|s| s.value)
             .max_by(|a, b| a.partial_cmp(b).unwrap())

--- a/src/service/promql/functions/min_over_time.rs
+++ b/src/service/promql/functions/min_over_time.rs
@@ -21,11 +21,11 @@ pub(crate) fn min_over_time(data: &Value) -> Result<Value> {
 }
 
 fn exec(data: &RangeValue) -> Option<f64> {
-    if data.values.is_empty() {
+    if data.samples.is_empty() {
         return None;
     }
     Some(
-        data.values
+        data.samples
             .iter()
             .map(|s| s.value)
             .min_by(|a, b| a.partial_cmp(b).unwrap())

--- a/src/service/promql/functions/mod.rs
+++ b/src/service/promql/functions/mod.rs
@@ -124,7 +124,7 @@ pub(crate) fn eval_idelta(
         }
         rate_values.push(InstantValue {
             labels,
-            value: Sample {
+            sample: Sample {
                 timestamp: metric.time_range.unwrap().1,
                 value: value.unwrap(),
             },

--- a/src/service/promql/functions/sum_over_time.rs
+++ b/src/service/promql/functions/sum_over_time.rs
@@ -21,8 +21,8 @@ pub(crate) fn sum_over_time(data: &Value) -> Result<Value> {
 }
 
 fn exec(data: &RangeValue) -> Option<f64> {
-    if data.values.is_empty() {
+    if data.samples.is_empty() {
         return None;
     }
-    Some(data.values.iter().map(|s| s.value).sum())
+    Some(data.samples.iter().map(|s| s.value).sum())
 }

--- a/src/service/promql/search/grpc/mod.rs
+++ b/src/service/promql/search/grpc/mod.rs
@@ -125,26 +125,26 @@ pub async fn search(
             }
             value::Value::Instant(v) => {
                 resp.result.push(cluster_rpc::Series {
-                    metric: v.labels.iter().map(|l| l.as_ref().into()).collect(),
-                    values: vec![],
-                    value: Some((&v.value).into()),
+                    metric: v.labels.iter().map(|x| x.as_ref().into()).collect(),
+                    samples: vec![],
+                    sample: Some((&v.sample).into()),
                     scalar: None,
                 });
             }
             value::Value::Range(v) => {
                 resp.result.push(cluster_rpc::Series {
-                    metric: v.labels.iter().map(|l| l.as_ref().into()).collect(),
-                    values: v.values.iter().map(|l| l.into()).collect(),
-                    value: None,
+                    metric: v.labels.iter().map(|x| x.as_ref().into()).collect(),
+                    samples: v.samples.iter().map(|x| x.into()).collect(),
+                    sample: None,
                     scalar: None,
                 });
             }
             value::Value::Vector(v) => {
                 v.iter().for_each(|v| {
                     resp.result.push(cluster_rpc::Series {
-                        metric: v.labels.iter().map(|l| l.as_ref().into()).collect(),
-                        values: vec![],
-                        value: Some((&v.value).into()),
+                        metric: v.labels.iter().map(|x| x.as_ref().into()).collect(),
+                        samples: vec![],
+                        sample: Some((&v.sample).into()),
                         scalar: None,
                     });
                 });
@@ -152,9 +152,9 @@ pub async fn search(
             value::Value::Matrix(v) => {
                 v.iter().for_each(|v| {
                     resp.result.push(cluster_rpc::Series {
-                        metric: v.labels.iter().map(|l| l.as_ref().into()).collect(),
-                        values: v.values.iter().map(|l| l.into()).collect(),
-                        value: None,
+                        metric: v.labels.iter().map(|x| x.as_ref().into()).collect(),
+                        samples: v.samples.iter().map(|x| x.into()).collect(),
+                        sample: None,
                         scalar: None,
                     });
                 });
@@ -162,16 +162,16 @@ pub async fn search(
             value::Value::Sample(v) => {
                 resp.result.push(cluster_rpc::Series {
                     metric: vec![],
-                    values: vec![],
-                    value: Some(v.into()),
+                    samples: vec![],
+                    sample: Some(v.into()),
                     scalar: None,
                 });
             }
             value::Value::Float(v) => {
                 resp.result.push(cluster_rpc::Series {
                     metric: vec![],
-                    values: vec![],
-                    value: None,
+                    samples: vec![],
+                    sample: None,
                     scalar: Some(*v),
                 });
             }

--- a/src/service/promql/search/mod.rs
+++ b/src/service/promql/search/mod.rs
@@ -273,25 +273,28 @@ async fn search_in_cluster(req: cluster_rpc::MetricsQueryRequest) -> Result<Valu
 fn merge_matrix_query(series: &[cluster_rpc::Series]) -> Value {
     let mut merged_data = FxHashMap::default();
     let mut merged_metrics = FxHashMap::default();
-    series.iter().for_each(|v| {
-        let labels: Labels = v.metric.iter().map(|v| Arc::new(Label::from(v))).collect();
-        let values: Vec<Sample> = v.values.iter().map(Sample::from).collect();
+    for ser in series {
+        let labels: Labels = ser
+            .metric
+            .iter()
+            .map(|l| Arc::new(Label::from(l)))
+            .collect();
+        let samples: Vec<Sample> = ser.samples.iter().map(Sample::from).collect();
         merged_data
             .entry(signature(&labels))
             .or_insert_with(Vec::new)
-            .extend(values);
+            .extend(samples);
         merged_metrics.insert(signature(&labels), labels);
-    });
+    }
     let merged_data = merged_data
         .into_iter()
-        .map(|(sig, values)| RangeValue {
+        .map(|(sig, samples)| RangeValue {
             labels: merged_metrics.get(&sig).unwrap().to_owned(),
-            values,
+            samples,
             time_range: None,
         })
         .collect::<Vec<_>>();
 
-    // sort data
     let mut value = Value::Matrix(merged_data);
     value.sort();
     value
@@ -304,21 +307,24 @@ fn merge_vector_query(series: &[cluster_rpc::Series]) -> Value {
         Vec<Arc<Label>>,
         std::hash::BuildHasherDefault<rustc_hash::FxHasher>,
     > = FxHashMap::default();
-    series.iter().for_each(|v| {
-        let labels: Labels = v.metric.iter().map(|v| Arc::new(Label::from(v))).collect();
-        let value: Sample = v.value.as_ref().unwrap().into();
-        merged_data.insert(signature(&labels), value);
+    for ser in series {
+        let labels: Labels = ser
+            .metric
+            .iter()
+            .map(|l| Arc::new(Label::from(l)))
+            .collect();
+        let sample: Sample = ser.sample.as_ref().unwrap().into();
+        merged_data.insert(signature(&labels), sample);
         merged_metrics.insert(signature(&labels), labels);
-    });
+    }
     let merged_data = merged_data
         .into_iter()
-        .map(|(sig, value)| InstantValue {
+        .map(|(sig, sample)| InstantValue {
             labels: merged_metrics.get(&sig).unwrap().to_owned(),
-            value,
+            sample,
         })
         .collect::<Vec<_>>();
 
-    // sort data
     let mut value = Value::Vector(merged_data);
     value.sort();
     value
@@ -326,13 +332,12 @@ fn merge_vector_query(series: &[cluster_rpc::Series]) -> Value {
 
 fn merge_scalar_query(series: &[cluster_rpc::Series]) -> Value {
     let mut sample: Sample = Default::default();
-    series.iter().for_each(|v| {
-        if v.scalar.is_some() {
-            sample.value = v.scalar.unwrap();
+    for ser in series {
+        if let Some(x) = ser.sample.as_ref() {
+            sample = x.into();
+        } else if let Some(x) = ser.scalar {
+            sample.value = x;
         }
-        if v.value.is_some() {
-            sample = v.value.as_ref().unwrap().into();
-        }
-    });
+    }
     Value::Sample(sample)
 }


### PR DESCRIPTION
Prometheus [only performs extrapolation] when applying `rate`,
`increase`, and `delta` functions.

[only performs extrapolation]: https://github.com/prometheus/prometheus/blob/b727e69b7601b069ded5c34348dca41b80988f4b/promql/functions.go#L63-L67

This patch fixes responses to `/range_query` API calls.
E.g., now sending `zo_http_incoming_requests{namespace="ziox-alpha1"}`
query to vanilla Prometheus and ZincObserve returns the same set
of samples, provided that have been no restarts of ZincObserve during
`[start, end]` time window.

Part of #747.

### Other changes

refactor: rename 'values' to 'samples'

Generic words like "value" and "data" may mean pretty much anything.
"Sample" is more precise --- in the context of time series a *sample*
is a pair of a timestamp and a *value*.

