### PR TITLE
feat: adopt Prometheus' `extrapolated_rate`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6403,6 +6403,7 @@ dependencies = [
  "expect-test",
  "flate2",
  "flatten-json-object",
+ "float-cmp",
  "futures",
  "get_if_addrs",
  "glob",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -156,3 +156,4 @@ tonic-build = { version = "0.8", features = ["prost"] }
 [dev-dependencies]
 datafusion-expr = "22"
 expect-test = "1.4"
+float-cmp = "0.9"

--- a/src/handler/grpc/mod.rs
+++ b/src/handler/grpc/mod.rs
@@ -144,12 +144,10 @@ impl From<&promql::value::Label> for cluster_rpc::Label {
 
 impl From<&cluster_rpc::Sample> for promql::value::Sample {
     fn from(req: &cluster_rpc::Sample) -> Self {
-        promql::value::Sample {
-            timestamp: req.time,
-            value: req.value,
-        }
+        promql::value::Sample::new(req.time, req.value)
     }
 }
+
 impl From<&promql::value::Sample> for cluster_rpc::Sample {
     fn from(req: &promql::value::Sample) -> Self {
         cluster_rpc::Sample {

--- a/src/service/promql/aggregations/avg.rs
+++ b/src/service/promql/aggregations/avg.rs
@@ -27,11 +27,8 @@ pub fn avg(timestamp: i64, param: &Option<LabelModifier>, data: &Value) -> Resul
         .values()
         .map(|v| InstantValue {
             labels: v.labels.clone(),
-            sample: Sample {
-                timestamp,
-                value: v.value / v.num as f64,
-            },
+            sample: Sample::new(timestamp, v.value / v.num as f64),
         })
-        .collect::<Vec<_>>();
+        .collect();
     Ok(Value::Vector(values))
 }

--- a/src/service/promql/aggregations/count.rs
+++ b/src/service/promql/aggregations/count.rs
@@ -25,13 +25,10 @@ pub fn count(timestamp: i64, param: &Option<LabelModifier>, data: &Value) -> Res
     let values = score_values
         .unwrap()
         .values()
-        .map(|v| InstantValue {
-            labels: v.labels.clone(),
-            sample: Sample {
-                timestamp,
-                value: v.num as f64,
-            },
+        .map(|it| InstantValue {
+            labels: it.labels.clone(),
+            sample: Sample::new(timestamp, it.num as _),
         })
-        .collect::<Vec<_>>();
+        .collect();
     Ok(Value::Vector(values))
 }

--- a/src/service/promql/aggregations/max.rs
+++ b/src/service/promql/aggregations/max.rs
@@ -37,13 +37,10 @@ pub fn max(timestamp: i64, param: &Option<LabelModifier>, data: &Value) -> Resul
     let values = score_values
         .unwrap()
         .values()
-        .map(|v| InstantValue {
-            labels: v.labels.clone(),
-            sample: Sample {
-                timestamp,
-                value: v.value,
-            },
+        .map(|it| InstantValue {
+            labels: it.labels.clone(),
+            sample: Sample::new(timestamp, it.value),
         })
-        .collect::<Vec<_>>();
+        .collect();
     Ok(Value::Vector(values))
 }

--- a/src/service/promql/aggregations/min.rs
+++ b/src/service/promql/aggregations/min.rs
@@ -31,13 +31,10 @@ pub fn min(timestamp: i64, param: &Option<LabelModifier>, data: &Value) -> Resul
     let values = score_values
         .unwrap()
         .values()
-        .map(|v| InstantValue {
-            labels: v.labels.clone(),
-            sample: Sample {
-                timestamp,
-                value: v.value,
-            },
+        .map(|it| InstantValue {
+            labels: it.labels.clone(),
+            sample: Sample::new(timestamp, it.value),
         })
-        .collect::<Vec<_>>();
+        .collect();
     Ok(Value::Vector(values))
 }

--- a/src/service/promql/aggregations/sum.rs
+++ b/src/service/promql/aggregations/sum.rs
@@ -25,13 +25,10 @@ pub fn sum(timestamp: i64, param: &Option<LabelModifier>, data: &Value) -> Resul
     let values = score_values
         .unwrap()
         .values()
-        .map(|v| InstantValue {
-            labels: v.labels.clone(),
-            sample: Sample {
-                timestamp,
-                value: v.value,
-            },
+        .map(|it| InstantValue {
+            labels: it.labels.clone(),
+            sample: Sample::new(timestamp, it.value),
         })
-        .collect::<Vec<_>>();
+        .collect();
     Ok(Value::Vector(values))
 }

--- a/src/service/promql/engine.rs
+++ b/src/service/promql/engine.rs
@@ -33,9 +33,9 @@ use std::{
     time::{Duration, SystemTime, UNIX_EPOCH},
 };
 
-use super::{aggregations, binaries, functions, value::*, TableProvider};
 use crate::infra::config::CONFIG;
 use crate::meta::prom::{MetricType, HASH_LABEL, VALUE_LABEL};
+use crate::service::promql::{aggregations, binaries, functions, value::*, TableProvider};
 
 pub struct QueryEngine {
     org_id: String,
@@ -102,31 +102,23 @@ impl QueryEngine {
         for i in 0..nr_steps {
             self.time_window_idx = i;
             match self.exec_expr(&stmt.expr).await? {
-                Value::Instant(v) => instant_vectors.push(RangeValue {
-                    labels: v.labels.to_owned(),
-                    time_range: None,
-                    samples: vec![v.sample],
-                }),
-                Value::Vector(vs) => instant_vectors.extend(vs.into_iter().map(|v| RangeValue {
-                    labels: v.labels.to_owned(),
-                    time_range: None,
-                    samples: vec![v.sample],
-                })),
+                Value::Instant(v) => {
+                    instant_vectors.push(RangeValue::new(v.labels.to_owned(), [v.sample]))
+                }
+                Value::Vector(vs) => instant_vectors.extend(
+                    vs.into_iter()
+                        .map(|v| RangeValue::new(v.labels.to_owned(), [v.sample])),
+                ),
                 Value::Range(v) => instant_vectors.push(v),
-                Value::Matrix(v) => instant_vectors.extend(v),
-                Value::Sample(v) => instant_vectors.push(RangeValue {
-                    labels: Labels::default(),
-                    time_range: None,
-                    samples: vec![v],
-                }),
-                Value::Float(v) => instant_vectors.push(RangeValue {
-                    labels: Labels::default(),
-                    time_range: None,
-                    samples: vec![Sample::new(
+                Value::Matrix(vs) => instant_vectors.extend(vs),
+                Value::Sample(s) => instant_vectors.push(RangeValue::new(Labels::default(), [s])),
+                Value::Float(val) => instant_vectors.push(RangeValue::new(
+                    Labels::default(),
+                    [Sample::new(
                         self.start + (self.interval * self.time_window_idx),
-                        v,
+                        val,
                     )],
-                }),
+                )),
                 Value::None => continue,
             };
         }
@@ -148,10 +140,8 @@ impl QueryEngine {
         }
         let merged_data = merged_data
             .into_iter()
-            .map(|(sig, values)| RangeValue {
-                labels: merged_metrics.get(&sig).unwrap().to_owned(),
-                time_range: None,
-                samples: values,
+            .map(|(sig, samples)| {
+                RangeValue::new(merged_metrics.get(&sig).unwrap().to_owned(), samples)
             })
             .collect::<Vec<_>>();
 
@@ -238,6 +228,9 @@ impl QueryEngine {
         })
     }
 
+    /// Instant vector selector --- select a single sample at each evaluation timestamp.
+    ///
+    /// See <https://promlabs.com/blog/2020/07/02/selecting-data-in-promql/#confusion-alert-instantrange-selectors-vs-instantrange-queries>
     async fn eval_vector_selector(
         &mut self,
         selector: &VectorSelector,
@@ -254,22 +247,23 @@ impl QueryEngine {
             None => return Ok(vec![]),
         };
 
-        let end = self.start + (self.interval * self.time_window_idx);
-        let start = end - self.lookback_delta;
+        // Evaluation timestamp.
+        let eval_ts = self.start + (self.interval * self.time_window_idx);
+        let start = eval_ts - self.lookback_delta;
 
         let mut values = vec![];
         for metric in metrics_cache {
             if let Some(last_value) = metric
                 .samples
                 .iter()
-                .filter_map(|s| (start < s.timestamp && s.timestamp <= end).then_some(s.value))
+                .filter_map(|s| (start < s.timestamp && s.timestamp <= eval_ts).then_some(s.value))
                 .last()
             {
                 values.push(
                     // See https://promlabs.com/blog/2020/06/18/the-anatomy-of-a-promql-query/#instant-queries
                     InstantValue {
                         labels: metric.labels.clone(),
-                        sample: Sample::new(end, last_value),
+                        sample: Sample::new(eval_ts, last_value),
                     },
                 );
             }
@@ -277,6 +271,10 @@ impl QueryEngine {
         Ok(values)
     }
 
+    /// Range vector selector --- select a whole time range at each evaluation timestamp.
+    ///
+    /// See <https://promlabs.com/blog/2020/07/02/selecting-data-in-promql/#confusion-alert-instantrange-selectors-vs-instantrange-queries>
+    ///
     /// MatrixSelector is a special case of VectorSelector that returns a matrix of samples.
     async fn eval_matrix_selector(
         &mut self,
@@ -295,21 +293,23 @@ impl QueryEngine {
             None => return Ok(vec![]),
         };
 
-        let end = self.start + (self.interval * self.time_window_idx); // 15s
-        let start = end - micros(range); // 5m
+        // Evaluation timestamp --- end of the time window.
+        let eval_ts = self.start + (self.interval * self.time_window_idx);
+        // Start of the time window.
+        let start = eval_ts - micros(range); // e.g. [5m]
 
         let mut values = Vec::with_capacity(metrics_cache.len());
         for metric in metrics_cache {
-            let metric_data = metric
+            let samples = metric
                 .samples
                 .iter()
-                .filter(|v| v.timestamp > start && v.timestamp <= end)
+                .filter(|v| start < v.timestamp && v.timestamp <= eval_ts)
                 .cloned()
-                .collect::<Vec<_>>();
+                .collect();
             values.push(RangeValue {
                 labels: metric.labels.clone(),
-                time_range: Some((start, end)),
-                samples: metric_data,
+                samples,
+                time_window: Some(TimeWindow::new(eval_ts, range)),
             });
         }
         Ok(values)
@@ -424,11 +424,7 @@ impl QueryEngine {
                         }));
                     }
                     labels.sort_by(|a, b| a.name.cmp(&b.name));
-                    RangeValue {
-                        labels,
-                        time_range: None,
-                        samples: Vec::with_capacity(20),
-                    }
+                    RangeValue::new(labels, Vec::with_capacity(20))
                 });
                 entry
                     .samples

--- a/src/service/promql/functions/histogram.rs
+++ b/src/service/promql/functions/histogram.rs
@@ -86,10 +86,7 @@ pub(crate) fn histogram_quantile(sample_time: i64, phi: f64, data: Value) -> Res
         .into_values()
         .map(|mb| InstantValue {
             labels: mb.labels,
-            sample: Sample {
-                timestamp: sample_time,
-                value: bucket_quantile(phi, mb.buckets),
-            },
+            sample: Sample::new(sample_time, bucket_quantile(phi, mb.buckets)),
         })
         .collect();
 

--- a/src/service/promql/functions/increase.rs
+++ b/src/service/promql/functions/increase.rs
@@ -14,14 +14,22 @@
 
 use datafusion::error::Result;
 
-use crate::service::promql::value::{RangeValue, Value};
+use crate::service::promql::value::{extrapolated_rate, ExtrapolationKind, RangeValue, Value};
 
 pub(crate) fn increase(data: &Value) -> Result<Value> {
     super::eval_idelta(data, "increase", exec)
 }
 
-fn exec(range: &RangeValue) -> Option<f64> {
-    range
-        .extrapolate()
-        .map(|(first, last)| last.value - first.value)
+fn exec(series: &RangeValue) -> Option<f64> {
+    let tw = series
+        .time_window
+        .as_ref()
+        .expect("BUG: `increase` function requires time window");
+    extrapolated_rate(
+        &series.samples,
+        tw.eval_ts,
+        tw.range,
+        tw.offset,
+        ExtrapolationKind::Increase,
+    )
 }

--- a/src/service/promql/functions/mod.rs
+++ b/src/service/promql/functions/mod.rs
@@ -118,17 +118,12 @@ pub(crate) fn eval_idelta(
     for metric in data.iter() {
         let mut labels = metric.labels.clone();
         labels.retain(|l| l.name != NAME_LABEL);
-        let value = fn_handler(metric);
-        if value.is_none() {
-            continue;
+        if let Some(value) = fn_handler(metric) {
+            rate_values.push(InstantValue {
+                labels,
+                sample: Sample::new(metric.time_range.unwrap().1, value),
+            });
         }
-        rate_values.push(InstantValue {
-            labels,
-            sample: Sample {
-                timestamp: metric.time_range.unwrap().1,
-                value: value.unwrap(),
-            },
-        });
     }
     Ok(Value::Vector(rate_values))
 }

--- a/src/service/promql/functions/mod.rs
+++ b/src/service/promql/functions/mod.rs
@@ -115,13 +115,14 @@ pub(crate) fn eval_idelta(
     };
 
     let mut rate_values = Vec::with_capacity(data.len());
-    for metric in data.iter() {
+    for metric in data {
         let mut labels = metric.labels.clone();
         labels.retain(|l| l.name != NAME_LABEL);
         if let Some(value) = fn_handler(metric) {
+            let eval_ts = metric.time_window.as_ref().unwrap().eval_ts;
             rate_values.push(InstantValue {
                 labels,
-                sample: Sample::new(metric.time_range.unwrap().1, value),
+                sample: Sample::new(eval_ts, value),
             });
         }
     }

--- a/src/service/promql/search/mod.rs
+++ b/src/service/promql/search/mod.rs
@@ -288,12 +288,10 @@ fn merge_matrix_query(series: &[cluster_rpc::Series]) -> Value {
     }
     let merged_data = merged_data
         .into_iter()
-        .map(|(sig, samples)| RangeValue {
-            labels: merged_metrics.get(&sig).unwrap().to_owned(),
-            samples,
-            time_range: None,
+        .map(|(sig, samples)| {
+            RangeValue::new(merged_metrics.get(&sig).unwrap().to_owned(), samples)
         })
-        .collect::<Vec<_>>();
+        .collect();
 
     let mut value = Value::Matrix(merged_data);
     value.sort();

--- a/src/service/promql/value.rs
+++ b/src/service/promql/value.rs
@@ -49,6 +49,12 @@ impl Serialize for Sample {
     }
 }
 
+impl Sample {
+    pub(crate) fn new(timestamp: i64, value: f64) -> Self {
+        Self { timestamp, value }
+    }
+}
+
 #[derive(Debug, Clone)]
 pub struct InstantValue {
     pub labels: Labels,
@@ -136,10 +142,7 @@ fn extrapolated_sample(p1: &Sample, p2: &Sample, t: i64) -> Sample {
     let dv = p2.value - p1.value;
     let dt2 = t - p1.timestamp;
     let dv2 = dv * dt2 as f64 / dt as f64;
-    Sample {
-        timestamp: t,
-        value: p1.value + dv2,
-    }
+    Sample::new(t, p1.value + dv2)
 }
 
 pub fn labels_value(labels: &Labels, name: &str) -> Option<String> {
@@ -274,38 +277,20 @@ mod tests {
 
     #[test]
     fn test_extrapolated_sample() {
-        let p1 = Sample {
-            timestamp: 100,
-            value: 10.0,
-        };
-        let p2 = Sample {
-            timestamp: 200,
-            value: 20.0,
-        };
+        let p1 = Sample::new(100, 10.0);
+        let p2 = Sample::new(200, 20.0);
         let p3 = extrapolated_sample(&p1, &p2, 300);
         assert_eq!(p3.timestamp, 300);
         assert_eq!(p3.value, 30.0);
 
-        let p1 = Sample {
-            timestamp: 225,
-            value: 1.0,
-        };
-        let p2 = Sample {
-            timestamp: 675,
-            value: 2.0,
-        };
+        let p1 = Sample::new(225, 1.0);
+        let p2 = Sample::new(675, 2.0);
         let p3 = extrapolated_sample(&p1, &p2, 750);
         let p4 = extrapolated_sample(&p1, &p2, 150);
         assert_eq!(format!("{:.2}", p3.value - p4.value), "1.33");
 
-        let p1 = Sample {
-            timestamp: 375,
-            value: 1.0,
-        };
-        let p2 = Sample {
-            timestamp: 675,
-            value: 2.0,
-        };
+        let p1 = Sample::new(375, 1.0);
+        let p2 = Sample::new(675, 2.0);
         let p3 = extrapolated_sample(&p1, &p2, 750);
         let p4 = extrapolated_sample(&p1, &p2, 300);
         assert_eq!(format!("{:.2}", p3.value - p4.value), "1.50");


### PR DESCRIPTION
Translate Prometheus' [`extrapolatedRate`] to Rust and use it.

[`extrapolatedRate`]: https://github.com/prometheus/prometheus/blob/80b7f73d267a812b3689321554aec637b75f468d/promql/functions.go#L67

Part of #747

