### PR TITLE
fix: make prometheus duplication configurable

### DIFF
--- a/src/infra/config.rs
+++ b/src/infra/config.rs
@@ -88,6 +88,7 @@ pub struct Config {
     pub sled: Sled,
     pub s3: S3,
     pub tcp: TCP,
+    pub prom: Prometheus,
 }
 
 #[derive(EnvConfig)]
@@ -323,6 +324,14 @@ pub struct S3 {
     pub connect_timeout: u64,
     #[env_config(name = "ZO_S3_FEATURE_FORCE_PATH_STYLE", default = false)]
     pub feature_force_path_style: bool,
+}
+
+#[derive(Debug, EnvConfig)]
+pub struct Prometheus {
+    #[env_config(name = "ZO_PROMETHEUS_HA_CLUSTER", default = "cluster")]
+    pub ha_cluster_label: String,
+    #[env_config(name = "ZO_PROMETHEUS_HA_REPLICA", default = "__replica__")]
+    pub ha_replica_label: String,
 }
 
 pub fn init() -> Config {

--- a/src/meta/prom.rs
+++ b/src/meta/prom.rs
@@ -25,9 +25,7 @@ pub const HASH_LABEL: &str = "__hash__";
 pub const VALUE_LABEL: &str = "value";
 pub const LE_LABEL: &str = "le";
 pub const QUANTILE_LABEL: &str = "quantile";
-pub const CLUSTER_LABEL: &str = "cluster";
-pub const REPLICA_LABEL: &str = "__replica__";
-pub const METADATA_LABEL: &str = "prom_metadata";
+pub const METADATA_LABEL: &str = "prom_metadata"; // for schema metadata key
 
 // See https://docs.rs/indexmap/latest/indexmap/#alternate-hashers
 pub type FxIndexMap<K, V> =

--- a/src/service/metrics/prom.rs
+++ b/src/service/metrics/prom.rs
@@ -37,9 +37,7 @@ use crate::{
     meta::{
         self,
         alert::{Alert, Trigger},
-        prom::{
-            self, CLUSTER_LABEL, HASH_LABEL, METADATA_LABEL, NAME_LABEL, REPLICA_LABEL, VALUE_LABEL,
-        },
+        prom::{self, HASH_LABEL, METADATA_LABEL, NAME_LABEL, VALUE_LABEL},
         StreamType,
     },
     service::{
@@ -122,11 +120,11 @@ pub async fn remote_write(
             None => continue,
         };
         if !has_entry {
-            if let Some(v) = labels_value(&event.labels, REPLICA_LABEL) {
+            if let Some(v) = labels_value(&event.labels, &CONFIG.prom.ha_replica_label) {
                 replica_label = v;
             };
             if cluster_name.is_empty() {
-                if let Some(v) = labels_value(&event.labels, CLUSTER_LABEL) {
+                if let Some(v) = labels_value(&event.labels, &CONFIG.prom.ha_cluster_label) {
                     cluster_name = format!("{}/{}", org_id, v);
                 }
             }
@@ -134,7 +132,10 @@ pub async fn remote_write(
         let labels: prom::FxIndexMap<String, String> = event
             .labels
             .iter()
-            .filter(|label| label.name != REPLICA_LABEL && label.name != CLUSTER_LABEL)
+            .filter(|label| {
+                label.name != CONFIG.prom.ha_replica_label
+                    && label.name != CONFIG.prom.ha_cluster_label
+            })
             .map(|label| (label.name.clone(), label.value.clone()))
             .collect();
 


### PR DESCRIPTION
Refer to: https://grafana.com/docs/mimir/latest/configure/configure-high-availability-deduplication/#how-to-configure-grafana-mimir

the labels of deduplication should be configure, like prometheus-operator default is:

```yaml
  external_labels:
    prometheus: monitoring/k8s
    prometheus_replica: prometheus-k8s-0
```