### PR TITLE
chore: added an api endpoint to trigger alerts

### DIFF
--- a/src/handler/http/router/mod.rs
+++ b/src/handler/http/router/mod.rs
@@ -163,6 +163,7 @@ pub fn get_service_routes(cfg: &mut web::ServiceConfig) {
             .service(save_alert)
             .service(get_alert)
             .service(list_alerts)
+            .service(trigger_alert)
             .service(list_stream_alerts)
             .service(delete_alert)
             .service(organization::organizations)

--- a/src/handler/http/router/openapi.rs
+++ b/src/handler/http/router/openapi.rs
@@ -49,6 +49,7 @@ use crate::meta;
         request::alerts::list_alerts,
         request::alerts::get_alert,
         request::alerts::delete_alert,
+        request::alerts::trigger_alert,
         request::alerts::templates::list_templates,
         request::alerts::templates::get_template,
         request::alerts::templates::save_template,

--- a/src/service/alerts/mod.rs
+++ b/src/service/alerts/mod.rs
@@ -233,7 +233,7 @@ pub async fn trigger_alert(
                 org: org_id,
                 last_sent_at: 0,
                 count: 0,
-                is_ingest_time: false, // Check with folks if this is correct
+                is_ingest_time: alert.is_real_time,
                 stream_type,
             };
             let _ = send_notification(&alert, &trigger).await;


### PR DESCRIPTION
Support testing a registered alert via triggers. An `PUT` handler is implemented on:
```
"/{org_id}/{stream_name}/alerts/{alert_name}/trigger"
```

Apart from the unit tests, I tested it using a very trivial echo server as the destination.
```go
✦ ❯ cat main.go 
package main

import (
	"fmt"

	"github.com/gofiber/fiber/v2"
)

func main() {
	app := fiber.New()

	app.Post("/", func(c *fiber.Ctx) error {
		fmt.Println(string(c.Body()))
		return c.SendString("Hello, World 👋!")
	})

	app.Listen(":8080")
}
```

