### PR TITLE
refactor: optimize the get_all_transform_keys function()

### DIFF
--- a/src/common/functions.rs
+++ b/src/common/functions.rs
@@ -5,17 +5,15 @@ use vector_enrichment::{Table, TableRegistry};
 use crate::meta::functions::VRLCompilerConfig;
 
 pub async fn get_all_transform_keys(org_id: &str) -> Vec<String> {
-    let mut fn_list = Vec::new();
-    for transform in crate::infra::config::QUERY_FUNCTIONS.iter() {
-        let key = transform.key();
-        let org_key = &format!("{}/", org_id);
-        if key.contains(org_key) {
-            if let Some(v) = key.strip_prefix(org_key).to_owned() {
-                fn_list.push(v.to_string())
-            }
-        }
-    }
-    fn_list
+    let org_key = &format!("{}/", org_id);
+
+    crate::infra::config::QUERY_FUNCTIONS
+        .iter()
+        .filter_map(|transform| {
+            let key = transform.key();
+            key.strip_prefix(org_key).map(|x| x.to_string())
+        })
+        .collect()
 }
 
 #[cfg(feature = "zo_functions")]


### PR DESCRIPTION
- Remove the stray `to_owned()` function
- Remove `contains()` function as only `strip_prefix()` is enough
- Move the `org_key` definiton out of the loop
- Make the overall function more idiomatic by removing `mut fn_list`