### PR TITLE
fix: regex - accept "-" in email

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -166,3 +166,6 @@ tonic-build = { version = "0.8", features = ["prost"] }
 datafusion-expr = "22"
 expect-test = "1.4"
 float-cmp = "0.9"
+
+[net]
+git-fetch-with-cli = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -167,5 +167,3 @@ datafusion-expr = "22"
 expect-test = "1.4"
 float-cmp = "0.9"
 
-[net]
-git-fetch-with-cli = true

--- a/deploy/build/buildspec-test.yml
+++ b/deploy/build/buildspec-test.yml
@@ -29,3 +29,4 @@ phases:
       - touch web/dist/index.html
       - cargo clippy -- -D warnings
       - ./coverage.sh
+

--- a/deploy/build/buildspec-test.yml
+++ b/deploy/build/buildspec-test.yml
@@ -15,6 +15,7 @@ phases:
       - rustup default nightly-2023-03-28  
       - rustup component add clippy llvm-tools
       - export RUSTFLAGS='-C target-cpu=native'
+      - rm -rf ~/.cargo/registry
 
   build:
     commands:

--- a/deploy/build/buildspec-test.yml
+++ b/deploy/build/buildspec-test.yml
@@ -27,6 +27,6 @@ phases:
       - pwd
       - mkdir -p web/dist 
       - touch web/dist/index.html
-      - cargo clippy -- -D warnings
+      - cargo --config net.git-fetch-with-cli=true clippy -- -D warnings
       - ./coverage.sh
 

--- a/src/job/mod.rs
+++ b/src/job/mod.rs
@@ -30,7 +30,7 @@ mod telemetry;
 
 pub async fn init() -> Result<(), anyhow::Error> {
     let email_regex = Regex::new(
-        r"^([a-z0-9_+]([a-z0-9_+.]*[a-z0-9_+])?)@([a-z0-9]+([\-\.]{1}[a-z0-9]+)*\.[a-z]{2,6})",
+        r"^([a-z0-9_+]([a-z0-9_+.-]*[a-z0-9_+])?)@([a-z0-9]+([\-\.]{1}[a-z0-9]+)*\.[a-z]{2,6})",
     )
     .expect("Email regex is valid");
 
@@ -153,6 +153,8 @@ pub async fn init() -> Result<(), anyhow::Error> {
 
     Ok(())
 }
+
+
 
 #[cfg(test)]
 mod tests {

--- a/src/job/mod.rs
+++ b/src/job/mod.rs
@@ -40,7 +40,7 @@ pub async fn init() -> Result<(), anyhow::Error> {
             || !email_regex.is_match(&CONFIG.auth.root_user_email)
             || CONFIG.auth.root_user_password.is_empty()
         {
-            panic!("Please set root user email-id & password using ZO_ROOT_USER_EMAIL & ZO_ROOT_USER_PASSWORD enviornment variables. This can also indicate an invalid email ID. Email ID must comply with ([a-z0-9_+]([a-z0-9_+.-]*[a-z0-9_+])?)@([a-z0-9]+([\-\.]{1}[a-z0-9]+)*\.[a-z]{2,6})");
+            panic!("Please set root user email-id & password using ZO_ROOT_USER_EMAIL & ZO_ROOT_USER_PASSWORD enviornment variables. This can also indicate an invalid email ID. Email ID must comply with ([a-z0-9_+]([a-z0-9_+.-]*[a-z0-9_+])?)@([a-z0-9]+([\\-\\.]{{1}}[a-z0-9]+)*\\.[a-z]{{2,6}})");
         }
         let _ = users::post_user(
             DEFAULT_ORG,

--- a/src/job/mod.rs
+++ b/src/job/mod.rs
@@ -40,7 +40,7 @@ pub async fn init() -> Result<(), anyhow::Error> {
             || !email_regex.is_match(&CONFIG.auth.root_user_email)
             || CONFIG.auth.root_user_password.is_empty()
         {
-            panic!("Please set root user email-id & password using ZO_ROOT_USER_EMAIL & ZO_ROOT_USER_PASSWORD enviornment variables");
+            panic!("Please set root user email-id & password using ZO_ROOT_USER_EMAIL & ZO_ROOT_USER_PASSWORD enviornment variables. This can also indicate an invalid email ID. Email ID must comply with ([a-z0-9_+]([a-z0-9_+.-]*[a-z0-9_+])?)@([a-z0-9]+([\-\.]{1}[a-z0-9]+)*\.[a-z]{2,6})");
         }
         let _ = users::post_user(
             DEFAULT_ORG,

--- a/web/README.md
+++ b/web/README.md
@@ -72,3 +72,4 @@ npm run test:e2e
 ```sh
 npm run lint
 ```
+


### PR DESCRIPTION
Start acceppting `-` in email id. Earlier hello-world@gmail.com would fail.

Now we would accept it. https://github.com/zinclabs/zincobserve/issues/807