### PR TITLE
fix: skip not exists fields for promql query

### DIFF
--- a/src/job/mod.rs
+++ b/src/job/mod.rs
@@ -154,8 +154,6 @@ pub async fn init() -> Result<(), anyhow::Error> {
     Ok(())
 }
 
-
-
 #[cfg(test)]
 mod tests {
     use std::env;

--- a/src/service/metrics/prom.rs
+++ b/src/service/metrics/prom.rs
@@ -534,8 +534,8 @@ pub(crate) async fn get_series(
     if let Some(selector) = selector {
         for mat in selector.matchers.matchers.iter() {
             if mat.name == CONFIG.common.column_timestamp
-                || mat.name == NAME_LABEL
                 || mat.name == VALUE_LABEL
+                || schema.field_with_name(&mat.name).is_err()
             {
                 continue;
             }

--- a/src/service/promql/mod.rs
+++ b/src/service/promql/mod.rs
@@ -13,9 +13,12 @@
 // limitations under the License.
 
 use async_trait::async_trait;
-use datafusion::{error::Result, prelude::SessionContext};
+use datafusion::{arrow::datatypes::Schema, error::Result, prelude::SessionContext};
 use serde::{Deserialize, Serialize};
-use std::time::{Duration, SystemTime, UNIX_EPOCH};
+use std::{
+    sync::Arc,
+    time::{Duration, SystemTime, UNIX_EPOCH},
+};
 use utoipa::ToSchema;
 
 mod aggregations;
@@ -39,7 +42,7 @@ pub trait TableProvider: Sync + Send + 'static {
         stream_name: &str,
         time_range: (i64, i64),
         filters: &[(&str, &str)],
-    ) -> Result<Vec<SessionContext>>;
+    ) -> Result<Vec<(SessionContext, Arc<Schema>)>>;
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize, ToSchema)]

--- a/src/service/promql/search/grpc/mod.rs
+++ b/src/service/promql/search/grpc/mod.rs
@@ -13,9 +13,12 @@
 // limitations under the License.
 
 use async_trait::async_trait;
-use datafusion::{error::DataFusionError, prelude::SessionContext};
+use datafusion::{arrow::datatypes::Schema, error::DataFusionError, prelude::SessionContext};
 use promql_parser::parser;
-use std::time::{Duration, UNIX_EPOCH};
+use std::{
+    sync::Arc,
+    time::{Duration, UNIX_EPOCH},
+};
 
 use crate::handler::grpc::cluster_rpc;
 use crate::infra::{cache::tmpfs, errors::Result};
@@ -40,7 +43,7 @@ impl TableProvider for StorageProvider {
         stream_name: &str,
         time_range: (i64, i64),
         filters: &[(&str, &str)],
-    ) -> datafusion::error::Result<Vec<SessionContext>> {
+    ) -> datafusion::error::Result<Vec<(SessionContext, Arc<Schema>)>> {
         let mut resp = Vec::new();
         // register storage table
         let ctx =


### PR DESCRIPTION
current version you will get error `the column not exists` when you query with a not exists field. 

But I tested Prometheus, it just skip it and return everything. So I made this change.