### PR TITLE
ci: constrain git hash to 7 characters forcefully

### DIFF
--- a/deploy/build/Dockerfile.mimalloc.aarch64
+++ b/deploy/build/Dockerfile.mimalloc.aarch64
@@ -1,0 +1,38 @@
+# syntax=docker/dockerfile:1
+FROM public.ecr.aws/docker/library/node:18.12.1-bullseye as webBuilder
+WORKDIR /web
+COPY ./web /web/
+
+RUN npm install
+RUN NODE_OPTIONS="--max-old-space-size=8192" npm run build
+
+# FROM public.ecr.aws/docker/library/rust:bullseye as builder
+FROM public.ecr.aws/zinclabs/rust:bullseye-sccache as builder
+
+# RUN rustup toolchain install nightly-2023-05-21
+# RUN rustup default nightly-2023-05-21
+# RUN rustup target add aarch64-unknown-linux-gnu
+# RUN diff -u <(rustc --print cfg) <(rustc -C target-cpu=native --print cfg)
+RUN rustc --version && sccache --version
+
+WORKDIR /app
+COPY . /app
+COPY --from=webBuilder /web/dist web/dist
+
+ENV CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc \
+  CC_aarch64_unknown_linux_gnu=aarch64-linux-gnu-gcc \
+  CXX_aarch64_unknown_linux_gnu=aarch64-linux-gnu-g++ \
+  RUSTFLAGS='-C target-feature=+aes,+crc,+lse,+neon'
+RUN --mount=type=cache,target=/root/.cache/sccache du -sh /root/.cache/sccache
+RUN --mount=type=cache,target=/root/.cache/sccache cargo build --release --features mimalloc --target aarch64-unknown-linux-gnu \
+  && sccache --show-stats \
+  && du -sh /root/.cache/sccache
+RUN mv /app/target/aarch64-unknown-linux-gnu/release/zincobserve /app/target/release/zincobserve
+
+# FROM gcr.io/distroless/cc:latest-arm64 as runtime
+FROM public.ecr.aws/debian/debian:bullseye-slim as runtime
+RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates
+RUN apt-get install -y curl htop iftop sysstat procps lsof net-tools
+RUN update-ca-certificates
+COPY --from=builder /app/target/release/zincobserve /
+CMD ["/zincobserve"]

--- a/deploy/build/buildspec-arm.yml
+++ b/deploy/build/buildspec-arm.yml
@@ -54,6 +54,12 @@ phases:
       - docker manifest push public.ecr.aws/zinclabs/zincobserve-dev:$GIT_TAG-$GIT_HASH
       - docker manifest push public.ecr.aws/zinclabs/zincobserve-dev:latest
 
+      # build zincobserve-mimalloc
+      - docker pull public.ecr.aws/zinclabs/rust:bullseye-sccache
+      - docker build -t zincobserve:latest-arm64-mimalloc -f deploy/build/Dockerfile.mimalloc.aarch64 .
+      - docker tag zincobserve:latest-arm64-mimalloc public.ecr.aws/zinclabs/zincobserve-dev:$GIT_TAG-$GIT_HASH-arm64-mimalloc
+      - docker push public.ecr.aws/zinclabs/zincobserve-dev:$GIT_TAG-$GIT_HASH-arm64-mimalloc
+
 cache:
   paths:
     - /root/.cache/

--- a/deploy/build/buildspec-arm.yml
+++ b/deploy/build/buildspec-arm.yml
@@ -14,8 +14,8 @@ phases:
       - swapon /swapfile || true
       - pwd
       - GIT_TAG="$(git describe --tags --abbrev=0)"
-      - GIT_HASH="$(git rev-parse --short HEAD)"
-      - echo "Building for commit - $GIT_HASH" 
+      - GIT_HASH="$(git rev-parse --short=7 HEAD)"
+      - echo "Building for commit - $GIT_HASH"
 
       # install buildx
       - wget -nv https://github.com/docker/buildx/releases/download/v0.10.4/buildx-v0.10.4.linux-arm64
@@ -45,11 +45,11 @@ phases:
       - echo 'Pull amd64 image'
       - docker pull public.ecr.aws/zinclabs/zincobserve-dev:$GIT_TAG-$GIT_HASH-amd64
       - docker pull public.ecr.aws/zinclabs/zincobserve-dev:latest-amd64
-       
+
       - echo 'Create manifests'
       - docker manifest create public.ecr.aws/zinclabs/zincobserve-dev:$GIT_TAG-$GIT_HASH --amend public.ecr.aws/zinclabs/zincobserve-dev:$GIT_TAG-$GIT_HASH-amd64 --amend public.ecr.aws/zinclabs/zincobserve-dev:$GIT_TAG-$GIT_HASH-arm64
       - docker manifest create public.ecr.aws/zinclabs/zincobserve-dev:latest --amend public.ecr.aws/zinclabs/zincobserve-dev:latest-amd64 --amend public.ecr.aws/zinclabs/zincobserve-dev:latest-arm64
-      
+
       - echo 'Push manifests'
       - docker manifest push public.ecr.aws/zinclabs/zincobserve-dev:$GIT_TAG-$GIT_HASH
       - docker manifest push public.ecr.aws/zinclabs/zincobserve-dev:latest

--- a/deploy/build/buildspec.yml
+++ b/deploy/build/buildspec.yml
@@ -40,9 +40,7 @@ phases:
       # - docker pull public.ecr.aws/zinclabs/rust:bullseye-sccache
       # - docker build -t zincobserve:latest-amd64-mimalloc -f deploy/build/Dockerfile.mimalloc.amd64 .
       # - docker tag zincobserve:latest-amd64-mimalloc public.ecr.aws/zinclabs/zincobserve-dev:$GIT_TAG-$GIT_HASH-amd64-mimalloc
-      # - docker tag zincobserve:latest-amd64-mimalloc public.ecr.aws/zinclabs/zincobserve-dev:latest-amd64-mimalloc
       # - docker push public.ecr.aws/zinclabs/zincobserve-dev:$GIT_TAG-$GIT_HASH-amd64-mimalloc
-      # - docker push public.ecr.aws/zinclabs/zincobserve-dev:latest-amd64-mimalloc
 
 cache:
   paths:

--- a/deploy/build/buildspec.yml
+++ b/deploy/build/buildspec.yml
@@ -14,7 +14,7 @@ phases:
       - swapon /swapfile || true
       - pwd
       - GIT_TAG="$(git describe --tags --abbrev=0)"
-      - GIT_HASH="$(git rev-parse --short HEAD)"
+      - GIT_HASH="$(git rev-parse --short=7 HEAD)"
       - echo "Building for commit - $GIT_HASH"
 
       # install buildx


### PR DESCRIPTION
constrain git hash to 7 characters forcefully. This should avoid the issue of arm build getting 8 characters hash and causing manifest issue and build failure